### PR TITLE
Feat/authorization handler

### DIFF
--- a/src/core/middleware_pipeline.py
+++ b/src/core/middleware_pipeline.py
@@ -3,7 +3,6 @@ import ssl
 from requests.adapters import HTTPAdapter
 from urllib3 import PoolManager
 
-
 class MiddlewarePipeline(HTTPAdapter):
     def __init__(self):
         super().__init__()

--- a/src/core/middleware_pipeline.py
+++ b/src/core/middleware_pipeline.py
@@ -3,6 +3,7 @@ import ssl
 from requests.adapters import HTTPAdapter
 from urllib3 import PoolManager
 
+
 class MiddlewarePipeline(HTTPAdapter):
     def __init__(self):
         super().__init__()

--- a/src/middleware/_base.py
+++ b/src/middleware/_base.py
@@ -1,0 +1,13 @@
+from abc import ABC, abstractmethod
+
+
+class TokenCredential(ABC):
+    @abstractmethod
+    def get_token(self, *scopes, **kwargs):
+        pass
+
+
+class AuthProviderBase(ABC):
+    @abstractmethod
+    def get_access_token(self):
+        pass

--- a/src/middleware/authorization_handler.py
+++ b/src/middleware/authorization_handler.py
@@ -1,0 +1,20 @@
+from requests.adapters import HTTPAdapter
+from ._base import AuthProviderBase
+
+
+class AuthorizationHandler(HTTPAdapter):
+    def __init__(self, auth_provider: AuthProviderBase):
+        super().__init__()
+
+        self.auth_provider = auth_provider
+        self.next=None
+
+    def send(self, request, stream=False, timeout=None, verify=True, cert=None, proxies=None):
+        token = self.auth_provider.get_access_token()
+
+        request.headers.update({'Authorization': 'Bearer {}'.format(token)})
+
+        if self.next is None:
+            return super().send(request, stream, timeout, verify, cert, proxies)
+
+        return self.next.send(request, stream, timeout, verify, cert, proxies)

--- a/src/middleware/authorization_provider.py
+++ b/src/middleware/authorization_provider.py
@@ -1,0 +1,10 @@
+from ._base import AuthProviderBase, TokenCredential
+
+
+class TokenCredentialAuthProvider(AuthProviderBase):
+    def __init__(self, credential: TokenCredential, scopes=''):
+        self.credential = credential
+        self.scopes = scopes
+
+    def get_access_token(self):
+        return self.credential.get_token(self.scopes)[0]

--- a/tests/integration/test_middleware_pipeline.py
+++ b/tests/integration/test_middleware_pipeline.py
@@ -1,8 +1,11 @@
 import warnings
 from unittest import TestCase
 
-from requests.adapters import HTTPAdapter
 from src.core.http_client_factory import HTTPClientFactory
+
+from src.middleware.authorization_provider import AuthProviderBase
+from src.middleware.authorization_handler import AuthorizationHandler
+
 
 
 class MiddlewarePipelineTest(TestCase):
@@ -11,8 +14,12 @@ class MiddlewarePipelineTest(TestCase):
 
     def test_middleware_pipeline(self):
         url = 'https://proxy.apisandbox.msdn.microsoft.com/svc?url=https://graph.microsoft.com/v1.0/me'
+
+        authProvider = _CustomAuthProvider()
+        authHandler = AuthorizationHandler(authProvider)
+
         middlewares = [
-            _AuthMiddleware()
+            authHandler
         ]
 
         requests = HTTPClientFactory.with_graph_middlewares(middlewares)
@@ -22,18 +29,10 @@ class MiddlewarePipelineTest(TestCase):
         self.assertEqual(result.status_code, 200)
 
 
-class _AuthMiddleware(HTTPAdapter):
-    def __init__(self):
-        super().__init__()
-        self.next = None
+class _CustomAuthProvider(AuthProviderBase):
 
-    def send(self, request, stream=False, timeout=None, verify=True, cert=None, proxies=None):
-        request.headers.update({'Authorization': 'Bearer {token:https://graph.microsoft.com/}'})
+    def get_access_token(self):
+        return '{token:https://graph.microsoft.com/}'
 
-        if self.next is None:
-            return super().send(request, stream, timeout, verify, cert, proxies)
-
-        response = self.next.send(request, stream, timeout, verify, cert, proxies)
-        return response
 
 

--- a/tests/integration/test_middleware_pipeline.py
+++ b/tests/integration/test_middleware_pipeline.py
@@ -7,7 +7,6 @@ from src.middleware.authorization_provider import AuthProviderBase
 from src.middleware.authorization_handler import AuthorizationHandler
 
 
-
 class MiddlewarePipelineTest(TestCase):
     def setUp(self):
         warnings.filterwarnings("ignore", category=ResourceWarning, message="unclosed.*<ssl.SSLSocket.*>")
@@ -15,11 +14,11 @@ class MiddlewarePipelineTest(TestCase):
     def test_middleware_pipeline(self):
         url = 'https://proxy.apisandbox.msdn.microsoft.com/svc?url=https://graph.microsoft.com/v1.0/me'
 
-        authProvider = _CustomAuthProvider()
-        authHandler = AuthorizationHandler(authProvider)
+        auth_provider = _CustomAuthProvider()
+        auth_handler = AuthorizationHandler(auth_provider)
 
         middlewares = [
-            authHandler
+            auth_handler
         ]
 
         requests = HTTPClientFactory.with_graph_middlewares(middlewares)


### PR DESCRIPTION
## Overview
Adds `TokenCredentialAuthProvider` and `AuthorizationHandler`

## How it works
Import a **Credential** class from **azure-identity** and create a credential object

```python
from azure-identity import ClientSecretCredential

credential = ClientSecretCredential('<tenant_id>', <client_id>', '<client_secret>')
```

Create an instance of **TokenCredentialAuthProvider** and pass in the `credential` object and `scopes` in the constructor

```python
authProvider = TokenCredentialAuthProvider(credential, 'https://graph.microsoft.com/.default')
```

Create an instance of **AuthorizationHandler** and pass the `authProvider` in its constructor.

```python
authHandler = AuthorizationHandler(authProvider)
```

Create a list of middlewares and pass it to the factory method

```python
middlewares = [
    authHandler
]

requests = HTTPClientFactory.with_graph_middlewares(middlewares)
```