### PR TITLE
Feat/support multiple scopes

### DIFF
--- a/src/middleware/_middleware.py
+++ b/src/middleware/_middleware.py
@@ -32,7 +32,7 @@ class MiddlewarePipeline(HTTPAdapter):
         request.middleware_control = MiddlewareControl()
 
         try:
-            scopes = kwargs.pop('scopes')
+            scopes = request.scopes
             auth_middleware_options = AuthMiddlewareOptions(scopes)
             request.middleware_control.set(AUTH_MIDDLEWARE_OPTIONS, auth_middleware_options)
         except KeyError:

--- a/src/middleware/authorization_handler.py
+++ b/src/middleware/authorization_handler.py
@@ -26,4 +26,4 @@ class AuthorizationHandler(Middleware):
         return response
 
     def _get_middleware_options(self, request):
-        return request.middleware_control.get(AUTH_MIDDLEWARE_OPTIONS) or self.auth_provider_options
+        return request.middleware_control.get(AUTH_MIDDLEWARE_OPTIONS)

--- a/src/middleware/options/auth_middleware_options.py
+++ b/src/middleware/options/auth_middleware_options.py
@@ -1,3 +1,20 @@
+from src.constants import BASE_URL
+
+
 class AuthMiddlewareOptions:
     def __init__(self, scopes=''):
         self.scopes = scopes
+
+    @property
+    def scopes(self):
+        return self._scopes
+
+    @scopes.setter
+    def scopes(self, list_of_scopes):
+        graph_scopes = BASE_URL + '?scopes='
+
+        for scope in list_of_scopes:
+            graph_scopes += scope + '%20'
+
+        self._scopes = graph_scopes
+

--- a/src/middleware/options/auth_middleware_options.py
+++ b/src/middleware/options/auth_middleware_options.py
@@ -2,7 +2,7 @@ from src.constants import BASE_URL
 
 
 class AuthMiddlewareOptions:
-    def __init__(self, scopes=''):
+    def __init__(self, scopes=[]):
         self.scopes = scopes
 
     @property
@@ -11,10 +11,12 @@ class AuthMiddlewareOptions:
 
     @scopes.setter
     def scopes(self, list_of_scopes):
-        graph_scopes = BASE_URL + '?scopes='
+        if type(list_of_scopes) == list:
+            graph_scopes = BASE_URL + '?scopes='
 
-        for scope in list_of_scopes:
-            graph_scopes += scope + '%20'
+            for scope in list_of_scopes:
+                graph_scopes += scope + '%20'
 
-        self._scopes = graph_scopes
-
+            self._scopes = graph_scopes
+        elif type(list_of_scopes) == str:
+            self._scopes = list_of_scopes

--- a/tests/unit/test_middleware_options.py
+++ b/tests/unit/test_middleware_options.py
@@ -1,0 +1,11 @@
+from unittest import TestCase
+
+from src.middleware.options.auth_middleware_options import AuthMiddlewareOptions
+
+
+class TestMiddlewareOptions(TestCase):
+    def test_multiple_scopes(self):
+        graph_scopes = 'https://graph.microsoft.com/v1.0?scopes=mail.read%20user.read%20'
+        auth_options = AuthMiddlewareOptions(scopes=['mail.read', 'user.read'])
+        self.assertEqual(auth_options.scopes, graph_scopes)
+

--- a/tests/unit/test_middleware_options.py
+++ b/tests/unit/test_middleware_options.py
@@ -8,4 +8,3 @@ class TestMiddlewareOptions(TestCase):
         graph_scopes = 'https://graph.microsoft.com/v1.0?scopes=mail.read%20user.read%20'
         auth_options = AuthMiddlewareOptions(scopes=['mail.read', 'user.read'])
         self.assertEqual(auth_options.scopes, graph_scopes)
-


### PR DESCRIPTION
## Overview
Support passing multiple scopes

1. Through AuthMiddlewareOptions
```python
auth_options = AuthMiddlewareOptions(scopes=['mail.read', 'user.read'])
```
2. Through middleware options
```python
result = graph_session.get(url, scopes=['mail.read', 'user.read'])
```

Closes #22 
