### PR TITLE
Fix/post requests

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -2,3 +2,4 @@ coverage==5.0.3
 pylint==2.4.4
 responses==0.10.12
 flit==2.2.0
+azure-identity==1.3.1

--- a/msgraphcore/constants.py
+++ b/msgraphcore/constants.py
@@ -6,5 +6,5 @@ CONNECTION_TIMEOUT = 30
 BASE_URL = 'https://graph.microsoft.com/v1.0'
 SDK_VERSION = '0.0.1-0'
 
-# MiddlewareOptions
+# Used as the key for AuthMiddlewareOption in MiddlewareControl
 AUTH_MIDDLEWARE_OPTIONS = 'AUTH_MIDDLEWARE_OPTIONS'

--- a/msgraphcore/graph_session.py
+++ b/msgraphcore/graph_session.py
@@ -25,6 +25,7 @@ class GraphSession(Session):
 
         auth_handler = AuthorizationHandler(auth_provider)
 
+        # The authorization handler should be the first middleware in the pipeline.
         middleware.insert(0, auth_handler)
         self._register(middleware)
 
@@ -87,7 +88,7 @@ class GraphSession(Session):
 
     def _graph_url(self, url: str) -> str:
         """Appends BASE_URL to user provided path
-        
+
         :param url: user provided path
         :return: graph_url
         """

--- a/msgraphcore/graph_session.py
+++ b/msgraphcore/graph_session.py
@@ -2,7 +2,7 @@
 Graph Session
 """
 
-from requests import Session, Response
+from requests import Session
 
 from msgraphcore.constants import BASE_URL, SDK_VERSION
 from msgraphcore.middleware._middleware import MiddlewarePipeline, BaseMiddleware
@@ -12,8 +12,11 @@ from msgraphcore.middleware.options.middleware_control import middleware_control
 
 
 class GraphSession(Session):
-    """
-    Extends session object with graph functionality
+    """Extends Session with Graph functionality
+
+    Extends Session by adding support for middleware options and middleware pipeline
+
+
     """
     def __init__(self, auth_provider: AuthProviderBase, middleware: list = []):
         super().__init__()
@@ -26,33 +29,79 @@ class GraphSession(Session):
         self._register(middleware)
 
     @middleware_control.get_middleware_options
-    def get(self, url, **kwargs):
+    def get(self, url: str, **kwargs):
+        r"""Sends a GET request. Returns :class:`Response` object.
+
+        :param url: URL for the new :class:`Request` object.
+        :param \*\*kwargs: Optional arguments that ``request`` takes.
+        :rtype: requests.Response
+        """
         return super().get(self._graph_url(url))
 
     @middleware_control.get_middleware_options
     def post(self, url, data=None, json=None, **kwargs):
+        r"""Sends a POST request. Returns :class:`Response` object.
+
+        :param url: URL for the new :class:`Request` object.
+        :param data: (optional) Dictionary, list of tuples, bytes, or file-like
+            object to send in the body of the :class:`Request`.
+        :param json: (optional) json to send in the body of the :class:`Request`.
+        :param \*\*kwargs: Optional arguments that ``request`` takes.
+        :rtype: requests.Response
+        """
         return super().post(self._graph_url(url), data, json, **kwargs)
 
     @middleware_control.get_middleware_options
     def put(self, url, data=None, **kwargs):
+        r"""Sends a PUT request. Returns :class:`Response` object.
+
+        :param url: URL for the new :class:`Request` object.
+        :param data: (optional) Dictionary, list of tuples, bytes, or file-like
+            object to send in the body of the :class:`Request`.
+        :param \*\*kwargs: Optional arguments that ``request`` takes.
+        :rtype: requests.Response
+        """
         return super().put(self._graph_url(url), data, **kwargs)
 
     @middleware_control.get_middleware_options
     def patch(self, url, data=None, **kwargs):
+        r"""Sends a PATCH request. Returns :class:`Response` object.
+
+        :param url: URL for the new :class:`Request` object.
+        :param data: (optional) Dictionary, list of tuples, bytes, or file-like
+            object to send in the body of the :class:`Request`.
+        :param \*\*kwargs: Optional arguments that ``request`` takes.
+        :rtype: requests.Response
+        """
         return super().patch(self._graph_url(url), data, **kwargs)
 
     @middleware_control.get_middleware_options
     def delete(self, url, **kwargs):
+        r"""Sends a DELETE request. Returns :class:`Response` object.
+
+        :param url: URL for the new :class:`Request` object.
+        :param \*\*kwargs: Optional arguments that ``request`` takes.
+        :rtype: requests.Response
+        """
         return super().delete(url, **kwargs)
 
-    def _graph_url(self, url: str) -> Response:
+    def _graph_url(self, url: str) -> str:
+        """Appends BASE_URL to user provided path
+        
+        :param url: user provided path
+        :return: graph_url
+        """
         return self._base_url+url if (url[0] == '/') else url
 
     def _register(self, middleware: [BaseMiddleware]) -> None:
+        """Adds middleware to middleware_pipeline
+
+        :param middleware: list of middleware
+        """
         if middleware:
-            middleware_adapter = MiddlewarePipeline()
+            middleware_pipeline = MiddlewarePipeline()
 
             for ware in middleware:
-                middleware_adapter.add_middleware(ware)
+                middleware_pipeline.add_middleware(ware)
 
-            self.mount('https://', middleware_adapter)
+            self.mount('https://', middleware_pipeline)

--- a/msgraphcore/graph_session.py
+++ b/msgraphcore/graph_session.py
@@ -1,22 +1,14 @@
 """
 Graph Session
 """
-from pprint import pprint
 
-from requests import Session, Request, Response
+from requests import Session, Response
 
 from msgraphcore.constants import BASE_URL, SDK_VERSION
 from msgraphcore.middleware._middleware import MiddlewarePipeline, BaseMiddleware
 from msgraphcore.middleware._base_auth import AuthProviderBase
 from msgraphcore.middleware.authorization import AuthorizationHandler
-
-
-def _get_middleware_options(func):
-    def wrapper(*args, **kwargs):
-        scopes = kwargs.pop('scopes')
-        print(scopes)
-        return func(*args, **kwargs)
-    return wrapper
+from msgraphcore.middleware.options.middleware_control import middleware_control
 
 
 class GraphSession(Session):
@@ -33,23 +25,23 @@ class GraphSession(Session):
         middleware.insert(0, auth_handler)
         self._register(middleware)
 
-    @_get_middleware_options
+    @middleware_control.get_middleware_options
     def get(self, url, **kwargs):
         return super().get(self._graph_url(url))
 
-    @_get_middleware_options
+    @middleware_control.get_middleware_options
     def post(self, url, data=None, json=None, **kwargs):
         return super().post(self._graph_url(url), data, json, **kwargs)
 
-    @_get_middleware_options
+    @middleware_control.get_middleware_options
     def put(self, url, data=None, **kwargs):
         return super().put(self._graph_url(url), data, **kwargs)
 
-    @_get_middleware_options
+    @middleware_control.get_middleware_options
     def patch(self, url, data=None, **kwargs):
         return super().patch(self._graph_url(url), data, **kwargs)
 
-    @_get_middleware_options
+    @middleware_control.get_middleware_options
     def delete(self, url, **kwargs):
         return super().delete(url, **kwargs)
 
@@ -64,22 +56,3 @@ class GraphSession(Session):
                 middleware_adapter.add_middleware(ware)
 
             self.mount('https://', middleware_adapter)
-
-    def _prepare_and_send_request(self, method: str = '', url: str = '', data=None, json=None, **kwargs) -> Response:
-        # Retrieve middleware options
-        list_of_scopes = kwargs.pop('scopes', None)
-
-        # Prepare request
-        request_url = self._graph_url(url)
-        request = Request(method, request_url, data=data, json=json, **kwargs)
-        pprint(request.__dict__)
-        prepared_request = self.prepare_request(request)
-
-        if list_of_scopes is not None:
-            # Append middleware options to the request object, will be used by MiddlewareController
-            prepared_request.scopes = list_of_scopes
-
-        return self.send(prepared_request, **kwargs)
-
-
-

--- a/msgraphcore/graph_session.py
+++ b/msgraphcore/graph_session.py
@@ -1,6 +1,8 @@
 """
 Graph Session
 """
+from pprint import pprint
+
 from requests import Session, Request, Response
 
 from msgraphcore.constants import BASE_URL, SDK_VERSION
@@ -26,8 +28,8 @@ class GraphSession(Session):
     def get(self, url: str, **kwargs) -> Response:
         return self._prepare_and_send_request('GET', url, **kwargs)
 
-    def post(self, url: str, **kwargs) -> Response:
-        return self._prepare_and_send_request('POST', url, **kwargs)
+    def post(self, url: str, data=None, json=None, **kwargs) -> Response:
+        return self._prepare_and_send_request('POST', url, data, json, **kwargs)
 
     def put(self, url: str, **kwargs) -> Response:
         return self._prepare_and_send_request('PUT', url, **kwargs)
@@ -50,13 +52,14 @@ class GraphSession(Session):
 
             self.mount('https://', middleware_adapter)
 
-    def _prepare_and_send_request(self, method: str = '', url: str = '', **kwargs) -> Response:
+    def _prepare_and_send_request(self, method: str = '', url: str = '', data=None, json=None, **kwargs) -> Response:
         # Retrieve middleware options
         list_of_scopes = kwargs.pop('scopes', None)
 
         # Prepare request
         request_url = self._get_url(url)
-        request = Request(method, request_url, kwargs)
+        request = Request(method, request_url, data=data, json=json, **kwargs)
+        pprint(request.__dict__)
         prepared_request = self.prepare_request(request)
 
         if list_of_scopes is not None:

--- a/msgraphcore/graph_session.py
+++ b/msgraphcore/graph_session.py
@@ -5,7 +5,6 @@ from requests import Session, Request, Response
 
 from msgraphcore.constants import BASE_URL, SDK_VERSION
 from msgraphcore.middleware._middleware import MiddlewarePipeline, BaseMiddleware
-from msgraphcore.middleware.options.auth_middleware_options import AuthMiddlewareOptions
 from msgraphcore.middleware._base_auth import AuthProviderBase
 from msgraphcore.middleware.authorization import AuthorizationHandler
 

--- a/msgraphcore/middleware/_middleware.py
+++ b/msgraphcore/middleware/_middleware.py
@@ -5,6 +5,11 @@ from urllib3 import PoolManager
 
 
 class MiddlewarePipeline(HTTPAdapter):
+    """MiddlewarePipeline, entry point of middleware
+
+    The pipeline is implemented as a linked-list, read more about
+    it here https://buffered.dev/middleware-python-requests/
+    """
     def __init__(self):
         super().__init__()
         self._middleware = None
@@ -27,6 +32,12 @@ class MiddlewarePipeline(HTTPAdapter):
 
 
 class BaseMiddleware(HTTPAdapter):
+    """Base class for middleware
+
+    Handles moving a Request to the next middleware in the pipeline.
+    If the current middleware is the last one in the pipeline, it
+    makes a network request
+    """
     def __init__(self):
         super().__init__()
         self.next = None

--- a/msgraphcore/middleware/_middleware.py
+++ b/msgraphcore/middleware/_middleware.py
@@ -3,10 +3,6 @@ import ssl
 from requests.adapters import HTTPAdapter
 from urllib3 import PoolManager
 
-from .options.auth_middleware_options import AuthMiddlewareOptions
-from .options.middleware_control import MiddlewareControl
-from ..constants import AUTH_MIDDLEWARE_OPTIONS
-
 
 class MiddlewarePipeline(HTTPAdapter):
     def __init__(self):
@@ -21,25 +17,10 @@ class MiddlewarePipeline(HTTPAdapter):
             self._middleware = middleware
 
     def send(self, request, **kwargs):
-        args = self._attach_middleware_control(request, **kwargs)
-
         if self._middleware_present():
-            return self._middleware.send(request, **args)
+            return self._middleware.send(request, **kwargs)
         # No middleware in pipeline, call superclass' send
-        return super().send(request, **args)
-
-    def _attach_middleware_control(self, request, **kwargs):
-        request.middleware_control = MiddlewareControl()
-
-        try:
-            scopes = request.scopes
-            auth_middleware_options = AuthMiddlewareOptions(scopes)
-            request.middleware_control.set(AUTH_MIDDLEWARE_OPTIONS, auth_middleware_options)
-        except KeyError:
-            # do nothing for now
-            pass
-        finally:
-            return kwargs
+        return super().send(request, **kwargs)
 
     def _middleware_present(self):
         return self._middleware

--- a/msgraphcore/middleware/_middleware.py
+++ b/msgraphcore/middleware/_middleware.py
@@ -22,6 +22,7 @@ class MiddlewarePipeline(HTTPAdapter):
 
     def send(self, request, **kwargs):
         args = self._attach_middleware_control(request, **kwargs)
+        args.pop('headers')
 
         if self._middleware_present():
             return self._middleware.send(request, **args)

--- a/msgraphcore/middleware/_middleware.py
+++ b/msgraphcore/middleware/_middleware.py
@@ -22,7 +22,6 @@ class MiddlewarePipeline(HTTPAdapter):
 
     def send(self, request, **kwargs):
         args = self._attach_middleware_control(request, **kwargs)
-        args.pop('headers')
 
         if self._middleware_present():
             return self._middleware.send(request, **args)

--- a/msgraphcore/middleware/authorization.py
+++ b/msgraphcore/middleware/authorization.py
@@ -29,7 +29,7 @@ class AuthorizationHandler(BaseMiddleware):
 
 
 class TokenCredentialAuthProvider(AuthProviderBase):
-    def __init__(self, credential: TokenCredential, scopes: [str] = ['user.read']):
+    def __init__(self, credential: TokenCredential, scopes: [str] = ['.default']):
         self.credential = credential
         self.scopes = scopes
 

--- a/msgraphcore/middleware/authorization.py
+++ b/msgraphcore/middleware/authorization.py
@@ -1,6 +1,7 @@
 from ._base_auth import AuthProviderBase, TokenCredential
 from ..constants import AUTH_MIDDLEWARE_OPTIONS
 from ._middleware import BaseMiddleware
+from .options.middleware_control import middleware_control
 
 
 class AuthorizationHandler(BaseMiddleware):
@@ -24,8 +25,8 @@ class AuthorizationHandler(BaseMiddleware):
 
         return response
 
-    def _get_middleware_options(self, request):
-        return request.middleware_control.get(AUTH_MIDDLEWARE_OPTIONS)
+    def _get_middleware_options(self):
+        return middleware_control.get(AUTH_MIDDLEWARE_OPTIONS)
 
 
 class TokenCredentialAuthProvider(AuthProviderBase):

--- a/msgraphcore/middleware/authorization.py
+++ b/msgraphcore/middleware/authorization.py
@@ -11,7 +11,7 @@ class AuthorizationHandler(BaseMiddleware):
         self.retry_count = 0
 
     def send(self, request, **kwargs):
-        options = self._get_middleware_options(request)
+        options = self._get_middleware_options()
         if options:
             self.auth_provider.scopes = options.scopes
 

--- a/msgraphcore/middleware/authorization.py
+++ b/msgraphcore/middleware/authorization.py
@@ -11,7 +11,7 @@ class AuthorizationHandler(BaseMiddleware):
         self.retry_count = 0
 
     def send(self, request, **kwargs):
-        # Checks if there're any options for this middleware
+        # Checks if there are any options for this middleware
         options = self._get_middleware_options()
         # If there is, get the scopes from the options
         if options:

--- a/msgraphcore/middleware/authorization.py
+++ b/msgraphcore/middleware/authorization.py
@@ -11,7 +11,9 @@ class AuthorizationHandler(BaseMiddleware):
         self.retry_count = 0
 
     def send(self, request, **kwargs):
+        # Checks if there're any options for this middleware
         options = self._get_middleware_options()
+        # If there is, get the scopes from the options
         if options:
             self.auth_provider.scopes = options.scopes
 
@@ -19,6 +21,7 @@ class AuthorizationHandler(BaseMiddleware):
         request.headers.update({'Authorization': 'Bearer {}'.format(token)})
         response = super().send(request, **kwargs)
 
+        # Token might have expired just before transmission, retry the request
         if response.status_code == 401 and self.retry_count < 2:
             self.retry_count += 1
             return self.send(request, **kwargs)

--- a/msgraphcore/middleware/options/auth_middleware_options.py
+++ b/msgraphcore/middleware/options/auth_middleware_options.py
@@ -1,5 +1,4 @@
 
 class AuthMiddlewareOptions:
-    def __init__(self, scopes: str):
+    def __init__(self, scopes: [str]):
         self.scopes = scopes
-

--- a/msgraphcore/middleware/options/middleware_control.py
+++ b/msgraphcore/middleware/options/middleware_control.py
@@ -16,8 +16,9 @@ class MiddlewareControl:
         self._reset_middleware_options()
 
         def wrapper(*args, **kwargs):
-            scopes = kwargs.pop('scopes')
-            self.set(AUTH_MIDDLEWARE_OPTIONS, AuthMiddlewareOptions(scopes))
+            scopes = kwargs.pop('scopes', None)
+            if scopes:
+                self.set(AUTH_MIDDLEWARE_OPTIONS, AuthMiddlewareOptions(scopes))
             return func(*args, **kwargs)
         return wrapper
 

--- a/msgraphcore/middleware/options/middleware_control.py
+++ b/msgraphcore/middleware/options/middleware_control.py
@@ -16,8 +16,10 @@ class MiddlewareControl:
         self._reset_middleware_options()
 
         def wrapper(*args, **kwargs):
+            # Get middleware options from **kwargs
             scopes = kwargs.pop('scopes', None)
             if scopes:
+                # Set middleware options, for use by middleware in the middleware pipeline
                 self.set(AUTH_MIDDLEWARE_OPTIONS, AuthMiddlewareOptions(scopes))
             return func(*args, **kwargs)
         return wrapper

--- a/msgraphcore/middleware/options/middleware_control.py
+++ b/msgraphcore/middleware/options/middleware_control.py
@@ -1,3 +1,7 @@
+from msgraphcore.constants import AUTH_MIDDLEWARE_OPTIONS
+from ..options.auth_middleware_options import AuthMiddlewareOptions
+
+
 class MiddlewareControl:
     def __init__(self):
         self.middleware_options = {}
@@ -7,3 +11,18 @@ class MiddlewareControl:
 
     def get(self, middleware_option_name):
         return self.middleware_options.get(middleware_option_name, None)
+
+    def get_middleware_options(self, func):
+        self._reset_middleware_options()
+
+        def wrapper(*args, **kwargs):
+            scopes = kwargs.pop('scopes')
+            self.set(AUTH_MIDDLEWARE_OPTIONS, AuthMiddlewareOptions(scopes))
+            return func(*args, **kwargs)
+        return wrapper
+
+    def _reset_middleware_options(self):
+        self.middleware_options = {}
+
+
+middleware_control = MiddlewareControl()

--- a/msgraphcore/middleware/options/middleware_control.py
+++ b/msgraphcore/middleware/options/middleware_control.py
@@ -25,6 +25,7 @@ class MiddlewareControl:
         return wrapper
 
     def _reset_middleware_options(self):
+        # Reset middleware, so that they are not persisted across requests
         self.middleware_options = {}
 
 

--- a/samples/samples.py
+++ b/samples/samples.py
@@ -1,0 +1,48 @@
+import json
+from pprint import pprint
+
+from azure.identity import InteractiveBrowserCredential
+from msgraphcore.middleware.authorization import TokenCredentialAuthProvider
+
+from msgraphcore import GraphSession
+
+browser_credential = InteractiveBrowserCredential(client_id='YOUR_CLIENT_ID')
+auth_provider = TokenCredentialAuthProvider(browser_credential)
+graph_session = GraphSession(auth_provider)
+
+
+def post_sample():
+    body = {
+        'message': {
+            'subject': 'Python SDK Meet for lunch?',
+            'body': {
+                'contentType': 'Text',
+                'content': 'The new cafeteria is open.'
+            },
+            'toRecipients': [
+                {
+                    'emailAddress': {
+                        'address': 'jaobala@microsoft.com'
+                    }
+                }
+            ]}
+    }
+
+    result = graph_session \
+        .post('/me/sendMail',
+              data=json.dumps(body),
+              scopes=['mail.send'],
+              headers={'Content-Type': 'application/json'}
+              )
+    pprint(result.status_code)
+
+
+def get_sample():
+    result = graph_session.get('/me/messages', scopes=['mail.read'])
+    pprint(result.json())
+
+
+if __name__ == '__main__':
+    post_sample()
+    get_sample()
+

--- a/samples/samples.py
+++ b/samples/samples.py
@@ -6,7 +6,7 @@ from msgraphcore.middleware.authorization import TokenCredentialAuthProvider
 
 from msgraphcore import GraphSession
 
-browser_credential = InteractiveBrowserCredential(client_id='YOUR_CLIENT_ID')
+browser_credential = InteractiveBrowserCredential(client_id='ENTER_YOUR_CLIENT_ID')
 auth_provider = TokenCredentialAuthProvider(browser_credential)
 graph_session = GraphSession(auth_provider)
 
@@ -22,7 +22,7 @@ def post_sample():
             'toRecipients': [
                 {
                     'emailAddress': {
-                        'address': 'jaobala@microsoft.com'
+                        'address': 'ENTER_RECEPIENT_EMAIL_ADDRESS'
                     }
                 }
             ]}


### PR DESCRIPTION
## Overview
This PRs makes the following changes
* Refactor how the middleware control is used
* Refactor how HTTP methods are implemented in GraphSession


## Why make these changes
GraphSession extends Session with Graph use cases like adding support for middleware options. To do this we were building a Request object and passing it through the middleware pipeline, together with other arguments -- ****kwargs**. This is where I went wrong with the previous implementation.

The [_prepare_and_send_request](https://github.com/microsoftgraph/msgraph-sdk-python-core/blob/2a716b32c123a84eeb0c50ecc69a697fa0f2b867/msgraphcore/graph_session.py#L48) method, built the request object, removed the scopes from **kwargs and mutated the request object by **adding** to it a **scopes** property. This was done because the **Request** constructor doesn't expect **scopes**  to be passed. It then sends the request object down the pipeline with some arguments. This breaks the send method -- **bug** -- when it gets arguments it doesn't expect like **headers**.

To fix this, I needed to stop drilling arguments from users to the send method. That means, I need to stop calling `send` in `_prepare_and_send_request`. So I decided to call Session's HTTP methods in GraphSession instead of prepare_and_send request.

```python
class GraphSession:
   def get(url, **kwargs)
       super().get(url, **kwargs)
```
instead of

```python
class GraphSession
     def get(url, **kwargs)
           self._prepare_and_send_request()
```

But now we have another bug, if we call `graph_session.get('/me', scopes=[])`, `get` will break because `super().get(url, **kwargs)` doesn't expect `scopes` to be in `**kwargs`. So I had to figure out a way of removing `scopes` or more broadly `middleware options`  -- from **kwargs -- before we call `super().get(url, **kwargs)`. I did this using a decorator.

```python
    def get_middleware_options(self, func):
        self._reset_middleware_options()

        def wrapper(*args, **kwargs):
            scopes = kwargs.pop('scopes')
            self.set(AUTH_MIDDLEWARE_OPTIONS, AuthMiddlewareOptions(scopes))
            return func(*args, **kwargs)
        return wrapper
``` 

The decorater lives in the [MiddlewareControl](https://github.com/microsoftgraph/msgraph-sdk-python-core/blob/c51407c71d7f18a88f18b3c8fb3954196f951f88/msgraphcore/middleware/options/middleware_control.py#L15) class. 

This how it is used

```python
    @middleware_control.get_middleware_options
    def get(self, url, **kwargs):
        return super().get(self._graph_url(url))
```

For all requests, the decorator does the following;
* Reset the `middleware_options` property, so that they are not persisted across requests
* Get and remove the middleware options from **kwargs, before it reaches `super().get(url, **kwargs)`
* Add the middleware options to `middleware_options`, for use in the middleware pipeline.

The `MiddlewareController` is exposed as a singleton for use in the `MiddlewarePipeline`. The snippet below demonstrates how it is used.

```python
middleware_control.get(AUTH_MIDDLEWARE_OPTIONS)
```

Fixes #39 
Closes #13 
Fixes [AB#4607](https://microsoftgraph.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_workitems/edit/4607)