### PR TITLE
Task/refactor graph session

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Import modules
 
 ```python
 from azure.identity import UsernamePasswordCredential, DeviceCodeCredential
-from msgraphcore import GraphSession, AuthorizationHandler, AuthMiddlewareOptions, TokenCredentialAuthProvider
+from msgraphcore import GraphSession
 ```
 
 Configure Credential Object
@@ -35,7 +35,6 @@ Pass the credential object and scopes to the GraphSession constructor.
 ```python
 scopes = ['mail.send', 'user.read']
 graph_session = GraphSession(device_credential, scopes)
-
 ```
 
 ```python

--- a/README.md
+++ b/README.md
@@ -31,13 +31,14 @@ device_credential = DeviceCodeCredential(
 
 ```
 
-Create an authorization provider object and a list of scopes
+Pass the credential object and scopes to the GraphSession constructor.
 ```python
 scopes = ['mail.send', 'user.read']
+graph_session = GraphSession(device_credential, scopes)
+
 ```
 
 ```python
-graph_session = GraphSession(device_credential, scopes)
 result = graph_session.get('/me')
 print(result.json())
 ```

--- a/README.md
+++ b/README.md
@@ -34,11 +34,10 @@ device_credential = DeviceCodeCredential(
 Create an authorization provider object and a list of scopes
 ```python
 scopes = ['mail.send', 'user.read']
-auth_provider = TokenCredentialAuthProvider(scopes, device_credential)
 ```
 
 ```python
-graph_session = GraphSession(auth_provider)
+graph_session = GraphSession(device_credential, scopes)
 result = graph_session.get('/me')
 print(result.json())
 ```

--- a/msgraphcore/__init__.py
+++ b/msgraphcore/__init__.py
@@ -1,7 +1,6 @@
 """msgraph-core"""
 
 from msgraphcore.graph_session import GraphSession
-from .middleware.authorization import AuthProviderBase, TokenCredentialAuthProvider
 from .constants import SDK_VERSION
 
 __version__ = SDK_VERSION

--- a/msgraphcore/constants.py
+++ b/msgraphcore/constants.py
@@ -4,7 +4,7 @@ Application constants
 REQUEST_TIMEOUT = 100
 CONNECTION_TIMEOUT = 30
 BASE_URL = 'https://graph.microsoft.com/v1.0'
-SDK_VERSION = '0.0.1-0'
+SDK_VERSION = '0.0.3'
 
 # Used as the key for AuthMiddlewareOption in MiddlewareControl
 AUTH_MIDDLEWARE_OPTIONS = 'AUTH_MIDDLEWARE_OPTIONS'

--- a/msgraphcore/graph_session.py
+++ b/msgraphcore/graph_session.py
@@ -15,7 +15,7 @@ class GraphSession(Session):
 
     Extends Session by adding support for middleware options and middleware pipeline
     """
-    def __init__(self, credential: TokenCredential, scopes: [str] = ['.default'],  middleware: list = []):
+    def __init__(self, credential: TokenCredential, scopes: [str] = ['.default'], middleware: list = []):
         super().__init__()
         self.headers.update({'sdkVersion': 'graph-python-' + SDK_VERSION})
         self._base_url = BASE_URL

--- a/msgraphcore/graph_session.py
+++ b/msgraphcore/graph_session.py
@@ -15,7 +15,11 @@ class GraphSession(Session):
 
     Extends Session by adding support for middleware options and middleware pipeline
     """
-    def __init__(self, credential: TokenCredential, scopes: [str] = ['.default'], middleware: list = []):
+    def __init__(self,
+                 credential: TokenCredential,
+                 scopes: [str] = ['.default'],
+                 middleware: list = []
+                 ):
         super().__init__()
         self.headers.update({'sdkVersion': 'graph-python-' + SDK_VERSION})
         self._base_url = BASE_URL

--- a/msgraphcore/graph_session.py
+++ b/msgraphcore/graph_session.py
@@ -1,12 +1,11 @@
 """
 Graph Session
 """
-
 from requests import Session
 
 from msgraphcore.constants import BASE_URL, SDK_VERSION
-from msgraphcore.middleware._middleware import MiddlewarePipeline, BaseMiddleware
-from msgraphcore.middleware._base_auth import AuthProviderBase
+from msgraphcore.middleware.middleware import MiddlewarePipeline, BaseMiddleware
+from msgraphcore.middleware.abc_token_credential import TokenCredential
 from msgraphcore.middleware.authorization import AuthorizationHandler
 from msgraphcore.middleware.options.middleware_control import middleware_control
 
@@ -15,15 +14,13 @@ class GraphSession(Session):
     """Extends Session with Graph functionality
 
     Extends Session by adding support for middleware options and middleware pipeline
-
-
     """
-    def __init__(self, auth_provider: AuthProviderBase, middleware: list = []):
+    def __init__(self, credential: TokenCredential, scopes: [str] = ['.default'],  middleware: list = []):
         super().__init__()
         self.headers.update({'sdkVersion': 'graph-python-' + SDK_VERSION})
         self._base_url = BASE_URL
 
-        auth_handler = AuthorizationHandler(auth_provider)
+        auth_handler = AuthorizationHandler(credential, scopes)
 
         # The authorization handler should be the first middleware in the pipeline.
         middleware.insert(0, auth_handler)

--- a/msgraphcore/middleware/abc_token_credential.py
+++ b/msgraphcore/middleware/abc_token_credential.py
@@ -6,8 +6,3 @@ class TokenCredential(ABC):
     def get_token(self, *scopes, **kwargs):
         pass
 
-
-class AuthProviderBase(ABC):
-    @abstractmethod
-    def get_access_token(self):
-        pass

--- a/msgraphcore/middleware/authorization.py
+++ b/msgraphcore/middleware/authorization.py
@@ -1,41 +1,33 @@
-from ._base_auth import AuthProviderBase, TokenCredential
 from ..constants import AUTH_MIDDLEWARE_OPTIONS
-from ._middleware import BaseMiddleware
+from .middleware import BaseMiddleware
 from .options.middleware_control import middleware_control
 
 
 class AuthorizationHandler(BaseMiddleware):
-    def __init__(self, auth_provider: AuthProviderBase):
+    def __init__(self, credential, scopes):
         super().__init__()
-        self.auth_provider = auth_provider
+        self.credential = credential
+        self.scopes = scopes
         self.retry_count = 0
 
     def send(self, request, **kwargs):
-        # Checks if there are any options for this middleware
-        options = self._get_middleware_options()
-        # If there is, get the scopes from the options
-        if options:
-            self.auth_provider.scopes = options.scopes
+        self._update_scopes_from_middleware_options()
 
-        token = self.auth_provider.get_access_token()
-        request.headers.update({'Authorization': 'Bearer {}'.format(token)})
+        request.headers.update({'Authorization': 'Bearer {}'.format(self._get_access_token())})
         response = super().send(request, **kwargs)
 
-        # Token might have expired just before transmission, retry the request
+        # Token might have expired just before transmission, retry the request one more time
         if response.status_code == 401 and self.retry_count < 2:
             self.retry_count += 1
             return self.send(request, **kwargs)
-
         return response
 
-    def _get_middleware_options(self):
-        return middleware_control.get(AUTH_MIDDLEWARE_OPTIONS)
+    def _update_scopes_from_middleware_options(self):
+        # Checks if there are any options for this middleware
+        auth_options_present = middleware_control.get(AUTH_MIDDLEWARE_OPTIONS)
+        # If there is, get the scopes from the options
+        if auth_options_present:
+            self.scopes = auth_options_present.scopes
 
-
-class TokenCredentialAuthProvider(AuthProviderBase):
-    def __init__(self, credential: TokenCredential, scopes: [str] = ['.default']):
-        self.credential = credential
-        self.scopes = scopes
-
-    def get_access_token(self):
+    def _get_access_token(self):
         return self.credential.get_token(*self.scopes)[0]

--- a/msgraphcore/middleware/middleware.py
+++ b/msgraphcore/middleware/middleware.py
@@ -1,7 +1,7 @@
 import ssl
+from urllib3 import PoolManager
 
 from requests.adapters import HTTPAdapter
-from urllib3 import PoolManager
 
 
 class MiddlewarePipeline(HTTPAdapter):

--- a/samples/samples.py
+++ b/samples/samples.py
@@ -1,14 +1,10 @@
 import json
 from pprint import pprint
-
 from azure.identity import InteractiveBrowserCredential
-from msgraphcore.middleware.authorization import TokenCredentialAuthProvider
-
 from msgraphcore import GraphSession
 
 browser_credential = InteractiveBrowserCredential(client_id='ENTER_YOUR_CLIENT_ID')
-auth_provider = TokenCredentialAuthProvider(browser_credential)
-graph_session = GraphSession(auth_provider)
+graph_session = GraphSession(browser_credential)
 
 
 def post_sample():

--- a/samples/samples.py
+++ b/samples/samples.py
@@ -3,8 +3,9 @@ from pprint import pprint
 from azure.identity import InteractiveBrowserCredential
 from msgraphcore import GraphSession
 
+scopes = ['user.read']
 browser_credential = InteractiveBrowserCredential(client_id='ENTER_YOUR_CLIENT_ID')
-graph_session = GraphSession(browser_credential)
+graph_session = GraphSession(browser_credential, scopes)
 
 
 def post_sample():

--- a/tests/integration/test_middleware_pipeline.py
+++ b/tests/integration/test_middleware_pipeline.py
@@ -19,7 +19,7 @@ class MiddlewarePipelineTest(TestCase):
 
 
 class _CustomTokenCredential:
-    def get_token(self, scopes = []):
+    def get_token(self, scopes):
         return ['{token:https://graph.microsoft.com/}']
 
 

--- a/tests/integration/test_middleware_pipeline.py
+++ b/tests/integration/test_middleware_pipeline.py
@@ -2,7 +2,6 @@ import warnings
 from unittest import TestCase
 
 from msgraphcore.graph_session import GraphSession
-from msgraphcore.middleware.authorization import AuthProviderBase
 
 
 class MiddlewarePipelineTest(TestCase):
@@ -12,19 +11,16 @@ class MiddlewarePipelineTest(TestCase):
     def test_middleware_pipeline(self):
         url = 'https://proxy.apisandbox.msdn.microsoft.com/svc?url=https://graph.microsoft.com/v1.0/me'
         scopes = ['user.read']
-        auth_provider = _CustomAuthProvider(scopes)
-        graph_session = GraphSession(auth_provider)
+        credential = _CustomTokenCredential()
+        graph_session = GraphSession(credential, scopes)
         result = graph_session.get(url)
 
         self.assertEqual(result.status_code, 200)
 
 
-class _CustomAuthProvider(AuthProviderBase):
-    def __init__(self, scopes):
-        pass
-
-    def get_access_token(self):
-        return '{token:https://graph.microsoft.com/}'
+class _CustomTokenCredential:
+    def get_token(self, scopes = []):
+        return ['{token:https://graph.microsoft.com/}']
 
 
 

--- a/tests/unit/test_auth_handler.py
+++ b/tests/unit/test_auth_handler.py
@@ -1,0 +1,29 @@
+import unittest
+
+from msgraphcore.constants import AUTH_MIDDLEWARE_OPTIONS
+from msgraphcore.middleware.authorization import AuthorizationHandler
+from msgraphcore.middleware.options.middleware_control import middleware_control
+from msgraphcore.middleware.options.auth_middleware_options import AuthMiddlewareOptions
+
+
+class TestAuthorizationHandler(unittest.TestCase):
+    def test_uses_scopes_from_auth_options(self):
+        auth_option = ['email.read']
+        default_scopes = ['.default']
+
+        middleware_control.set(AUTH_MIDDLEWARE_OPTIONS, AuthMiddlewareOptions(auth_option))
+        auth_handler = AuthorizationHandler(None, default_scopes)
+
+        auth_handler_scopes = auth_handler.get_scopes()
+        self.assertEqual(auth_option, auth_handler_scopes)
+
+    def test_auth_option_does_not_overwrite_default_scopes(self):
+        auth_option = ['email.read']
+        default_scopes = ['.default']
+
+        middleware_control.set(AUTH_MIDDLEWARE_OPTIONS, AuthMiddlewareOptions(auth_option))
+        auth_handler = AuthorizationHandler(None, default_scopes)
+
+        self.assertEqual(auth_handler.scopes, default_scopes)
+
+

--- a/tests/unit/test_auth_handler.py
+++ b/tests/unit/test_auth_handler.py
@@ -23,6 +23,7 @@ class TestAuthorizationHandler(unittest.TestCase):
 
         middleware_control.set(AUTH_MIDDLEWARE_OPTIONS, AuthMiddlewareOptions(auth_option))
         auth_handler = AuthorizationHandler(None, default_scopes)
+        auth_handler.get_scopes()
 
         self.assertEqual(auth_handler.scopes, default_scopes)
 

--- a/tests/unit/test_auth_handler.py
+++ b/tests/unit/test_auth_handler.py
@@ -7,7 +7,7 @@ from msgraphcore.middleware.options.auth_middleware_options import AuthMiddlewar
 
 
 class TestAuthorizationHandler(unittest.TestCase):
-    def test_uses_scopes_from_auth_options(self):
+    def test_auth_options_override_default_scopes(self):
         auth_option = ['email.read']
         default_scopes = ['.default']
 
@@ -17,7 +17,7 @@ class TestAuthorizationHandler(unittest.TestCase):
         auth_handler_scopes = auth_handler.get_scopes()
         self.assertEqual(auth_option, auth_handler_scopes)
 
-    def test_auth_option_does_not_overwrite_default_scopes(self):
+    def test_auth_handler_get_scopes_does_not_overwrite_default_scopes(self):
         auth_option = ['email.read']
         default_scopes = ['.default']
 

--- a/tests/unit/test_graph_session.py
+++ b/tests/unit/test_graph_session.py
@@ -6,7 +6,7 @@ import responses
 
 from msgraphcore.graph_session import GraphSession
 from msgraphcore.constants import BASE_URL, SDK_VERSION
-from msgraphcore.middleware._base_auth import AuthProviderBase
+from msgraphcore.middleware.abc_token_credential import AuthProviderBase
 
 
 class GraphSessionTest(TestCase):

--- a/tests/unit/test_graph_session.py
+++ b/tests/unit/test_graph_session.py
@@ -6,13 +6,12 @@ import responses
 
 from msgraphcore.graph_session import GraphSession
 from msgraphcore.constants import BASE_URL, SDK_VERSION
-from msgraphcore.middleware.abc_token_credential import AuthProviderBase
 
 
 class GraphSessionTest(TestCase):
     def setUp(self) -> None:
-        self.auth_provider = _CustomAuthProvider(['user.read'])
-        self.requests = GraphSession(self.auth_provider)
+        self.credential = _CustomTokenCredential()
+        self.requests = GraphSession(self.credential, ['user.read'])
 
     def tearDown(self) -> None:
         self.requests = None
@@ -27,7 +26,7 @@ class GraphSessionTest(TestCase):
         self.assertEqual(self.requests.headers.get('sdkVersion'), 'graph-python-'+SDK_VERSION)
 
     def test_initialized_with_middlewares(self):
-        graph_session = GraphSession(self.auth_provider)
+        graph_session = GraphSession(self.credential)
         mocked_middleware = graph_session.get_adapter('https://')
 
         self.assertIsInstance(mocked_middleware, HTTPAdapter)
@@ -53,9 +52,6 @@ class GraphSessionTest(TestCase):
         self.assertEqual(other_url, request_url)
 
 
-class _CustomAuthProvider(AuthProviderBase):
-    def __init__(self, scopes):
-        pass
-
-    def get_access_token(self):
-        return '{token:https://graph.microsoft.com/}'
+class _CustomTokenCredential:
+    def get_token(self, scopes):
+        return ['{token:https://graph.microsoft.com/}']

--- a/tests/unit/test_middleware_pipeline.py
+++ b/tests/unit/test_middleware_pipeline.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 from unittest import TestCase
 
-from msgraphcore.middleware._middleware import MiddlewarePipeline, BaseMiddleware
+from msgraphcore.middleware.middleware import MiddlewarePipeline, BaseMiddleware
 
 
 class MiddlewarePipelineTest(TestCase):


### PR DESCRIPTION
## Overview
Changes `GraphSession` to take in an Azure credential object and scopes.
Removes `AuthProvider`

Closes #44 #45 [AB#4607](https://microsoftgraph.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_workitems/edit/4607)