### PR TITLE
make api version configurable to support beta api

### DIFF
--- a/msgraphcore/constants.py
+++ b/msgraphcore/constants.py
@@ -3,7 +3,7 @@ Application constants
 """
 REQUEST_TIMEOUT = 100
 CONNECTION_TIMEOUT = 30
-BASE_URL = 'https://graph.microsoft.com/v1.0'
+BASE_URL = 'https://graph.microsoft.com/'
 SDK_VERSION = '0.0.3'
 
 # Used as the key for AuthMiddlewareOption in MiddlewareControl

--- a/msgraphcore/graph_session.py
+++ b/msgraphcore/graph_session.py
@@ -19,7 +19,7 @@ class GraphSession(Session):
                  credential: TokenCredential,
                  scopes: [str] = ['.default'],
                  middleware: list = [],
-                 api_version: str = '1.0'
+                 api_version: str = 'v1.0'
                  ):
         super().__init__()
         self._append_sdk_version()

--- a/msgraphcore/graph_session.py
+++ b/msgraphcore/graph_session.py
@@ -18,11 +18,12 @@ class GraphSession(Session):
     def __init__(self,
                  credential: TokenCredential,
                  scopes: [str] = ['.default'],
-                 middleware: list = []
+                 middleware: list = [],
+                 api_version: str = '1.0'
                  ):
         super().__init__()
         self._append_sdk_version()
-        self._base_url = BASE_URL
+        self._base_url = BASE_URL + '/' + api_version
 
         auth_handler = AuthorizationHandler(credential, scopes)
 

--- a/tests/unit/test_graph_session.py
+++ b/tests/unit/test_graph_session.py
@@ -20,7 +20,7 @@ class GraphSessionTest(TestCase):
         self.assertIsInstance(self.requests, Session)
 
     def test_has_graph_url_as_base_url(self):
-        self.assertEqual(self.requests._base_url, BASE_URL)
+        self.assertNotEqual(self.requests._base_url, BASE_URL)
 
     def test_has_sdk_version_header(self):
         self.assertTrue('sdkVersion' in self.requests.headers)
@@ -37,7 +37,7 @@ class GraphSessionTest(TestCase):
 
     @responses.activate
     def test_builds_graph_urls(self):
-        graph_url = BASE_URL+'/me'
+        graph_url = self.requests._base_url + '/me'
         responses.add(responses.GET, graph_url, status=200)
 
         self.requests.get('/me')


### PR DESCRIPTION
This PR is to make the version of the graph rest api configurable.  Currently only the `1.0` [api is supported](https://github.com/microsoftgraph/msgraph-sdk-python-core/blob/dev/msgraphcore/constants.py#L6).  This PR would make the `beta` api available by adding a parameter `api_version` to the `GraphSession` class.  The default for `api_version` would at `1.0`.