### PR TITLE
fix broken delete function and pyproject.toml

### DIFF
--- a/msgraphcore/graph_session.py
+++ b/msgraphcore/graph_session.py
@@ -85,7 +85,7 @@ class GraphSession(Session):
         :param \*\*kwargs: Optional arguments that ``request`` takes.
         :rtype: requests.Response
         """
-        return super().delete(url, **kwargs)
+        return super().delete(self._graph_url(url), **kwargs)
 
     def _graph_url(self, url: str) -> str:
         """Appends BASE_URL to user provided path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit_core >=2,<3", "requests = 2.23.0"]
+requires = ["flit_core >=2,<3", "requests >= 2.23.0"]
 build-backend = "flit_core.buildapi"
 
 [tool.flit.metadata]


### PR DESCRIPTION
This PR is to fix the delete function which generates a wrong url. Currently trying to use `graph_session.delete()` will fail.