### PR TITLE
Added Consistency Level as required for some calls

### DIFF
--- a/msgraphcore/middleware/authorization.py
+++ b/msgraphcore/middleware/authorization.py
@@ -12,7 +12,7 @@ class AuthorizationHandler(BaseMiddleware):
         self.retry_count = 0
 
     def send(self, request, **kwargs):
-        request.headers.update({'Authorization': 'Bearer {}'.format(self._get_access_token()), 'ConsistencyLevel': "eventual"})
+        request.headers.update({'Authorization': 'Bearer {}'.format(self._get_access_token()), 'ConsistencyLevel': 'eventual'})
         response = super().send(request, **kwargs)
 
         # Token might have expired just before transmission, retry the request one more time

--- a/msgraphcore/middleware/authorization.py
+++ b/msgraphcore/middleware/authorization.py
@@ -12,7 +12,7 @@ class AuthorizationHandler(BaseMiddleware):
         self.retry_count = 0
 
     def send(self, request, **kwargs):
-        request.headers.update({'Authorization': 'Bearer {}'.format(self._get_access_token())})
+        request.headers.update({'Authorization': 'Bearer {}'.format(self._get_access_token()), 'ConsistencyLevel': "eventual"})
         response = super().send(request, **kwargs)
 
         # Token might have expired just before transmission, retry the request one more time


### PR DESCRIPTION
ConsistencyLevel | eventual. This header and $count are required when using $search, or when using $filter with the $orderby query parameter. It uses an index that may not be up-to-date with recent changes to the object.

Added this to Authorization Middleware as I found appropriate


