### PR TITLE
Allow post requests without content-type header

### DIFF
--- a/msgraph/core/middleware/retry.py
+++ b/msgraph/core/middleware/retry.py
@@ -165,7 +165,7 @@ class RetryHandler(BaseMiddleware):
         """
         if response.request.method.upper() in frozenset(['HEAD', 'GET', 'DELETE', 'OPTIONS']):
             return True
-        if response.request.headers['Content-Type'] == "application/octet-stream":
+        if response.request.headers.get('Content-Type') == "application/octet-stream":
             return False
         return True
 


### PR DESCRIPTION
## Overview

Fixes an issue where `PUT`/`PATCH`/`POST` requests will fail on retry if there is no `content-type` header supplied in the request. `requests` library will only set the `Content-Type` if you use `data`, `files` or `json` as arguments

### Demo

N/A

### Notes

N/A

## Testing Instructions
N/A

closes #108 