### PR TITLE
#225: Split testing and release pipeline

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,19 +1,18 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Build and publish
+name: Build and test
 
 on:
-  workflow_dispatch:
   push:
-    branches: [kiota/long-term-branch]
   pull_request:
-    branches: [kiota/long-term-branch]
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     strategy:
+      max-parallel: 5
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
@@ -44,28 +43,3 @@ jobs:
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-
-  publish:
-    name: Publish distribution to PyPI
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/kiota/long-term-branch' }}
-    runs-on: ubuntu-latest
-    environment: pypi_prod
-    needs: [build]
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.11
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install build
-      - name: Build package
-        run: python -m build
-      - name: Publish package
-        uses: pypa/gh-action-pypi-publish@a56da0b891b3dc519c7ee3284aff1fad93cc8598
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,33 +14,8 @@ jobs:
         - name: Build
           uses: ./.github/workflows/python.yml
 
-  autorelease:
-    name: Create release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.8
-      - name: Release Notes
-        run: |
-          git log $(git describe HEAD~ --tags --abbrev=0)..HEAD --pretty='format:* %h %s%n' --no-merges >> ".github/RELEASE-TEMPLATE.md"
-      - name: Create Release Draft
-        uses: softprops/action-gh-release@v1
-        if: github.repository == 'microsoftgraph/msgraph-sdk-python-core' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-        with:
-          body_path: ".github/RELEASE-TEMPLATE.md"
-          draft: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   publish:
     name: Publish distribution to PyPI
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/kiota/long-term-branch' }}
     runs-on: ubuntu-latest
     environment: pypi_prod
     needs: [build]
@@ -62,3 +37,30 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}
+
+  autorelease:
+    name: Create release
+    runs-on: ubuntu-latest
+    needs: [build, publish]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+      - name: Release Notes
+        run: |
+          git log $(git describe HEAD~ --tags --abbrev=0)..HEAD --pretty='format:* %h %s%n' --no-merges >> ".github/RELEASE-TEMPLATE.md"
+      - name: Create Release Draft
+        uses: softprops/action-gh-release@v1
+        if: github.repository == 'microsoftgraph/msgraph-sdk-python-core' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        with:
+          body_path: ".github/RELEASE-TEMPLATE.md"
+          draft: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,10 +2,18 @@ name: Create a release
 
 on:
   push:
+    branches: [kiota/long-term-branch]
     tags:
       - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
 
 jobs:
+  build:
+      runs-on: ubuntu-latest
+      timeout-minutes: 60
+      steps:
+        - name: Build
+          uses: ./.github/workflows/python.yml
+
   autorelease:
     name: Create release
     runs-on: ubuntu-latest
@@ -29,3 +37,28 @@ jobs:
           draft: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    name: Publish distribution to PyPI
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/kiota/long-term-branch' }}
+    runs-on: ubuntu-latest
+    environment: pypi_prod
+    needs: [build]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+      - name: Build package
+        run: python -m build
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@a56da0b891b3dc519c7ee3284aff1fad93cc8598
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
- [X] Split testing and release pipeline, maintaining the build and test dependency on release one, which will get triggered just on push on your default branch.
- [X] Adds timeout minutes so that in case of error we save computing resources
- [X] Adds maximum parallel job
- [X] Make sure that build and testing pipeline runs on every push operation and PR.
- [X] Adds dependency between build and test => release and pip publish package steps.
- [X] Remove `    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/kiota/long-term-branch' }}`, as it is not longer needed now they are splitted.