### PR TITLE
Chore/update workflows to use main

### DIFF
--- a/.github/policies/msgraph-sdk-python-core.yml
+++ b/.github/policies/msgraph-sdk-python-core.yml
@@ -44,9 +44,9 @@ configuration:
     # Restrict who can dismiss pull request reviews. boolean
     restrictsReviewDismissals: false
 
-  - branchNamePattern: master
-    # This branch pattern applies to the following branches as of 06/12/2023 11:37:28:
-    # master
+  - branchNamePattern: main
+    # This branch pattern applies to the following branches as of 01/12/2024 13:14:28:
+    # main
 
     # Specifies whether this branch can be deleted. boolean
     allowsDeletions: false

--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -2,7 +2,7 @@ name: Auto-merge dependabot updates
 
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
 
 permissions:
   pull-requests: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish package to PyPI and create release
 
 on:
   push:
-    branches: [master]
+    branches: [main]
 
 jobs:
   build:


### PR DESCRIPTION
## Overview

Updates workflows and policies to use `main` as primary branch instead of `master`