### PR TITLE
Chore/update workflows

### DIFF
--- a/.github/workflows/conflicting-pr-label.yml
+++ b/.github/workflows/conflicting-pr-label.yml
@@ -11,7 +11,11 @@ on:
     types: [synchronize]
     branches: [main, dev]
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+permissions:
+  pull-requests: write
+  contents: read
+
+  # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
   build:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,9 +2,11 @@ name: Publish package to PyPI and create release
 
 on:
   push:
-    branches: [main]
     tags:
       - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
+
+permissions:
+  contents: write
 
 jobs:
   build:


### PR DESCRIPTION
## Overview
Updates publish workflow to only trigger publishing on tags push
Updates workflows to reflect https://docs.opensource.microsoft.com/github/apps/permission-changes/