### PR TITLE
Remove unnecessary printout

### DIFF
--- a/src/msgraph_core/tasks/page_iterator.py
+++ b/src/msgraph_core/tasks/page_iterator.py
@@ -67,6 +67,8 @@ Methods:
             parsable_factory = type(response)
         elif constructor_callable is None:
             parsable_factory = PageResult
+        else:
+            raise ValueError('One of the constructor_callable or the PageResult type parameter is required.')
         self.parsable_factory = parsable_factory
         self.pause_index = 0
         self.headers: HeadersCollection = HeadersCollection()

--- a/src/msgraph_core/tasks/page_iterator.py
+++ b/src/msgraph_core/tasks/page_iterator.py
@@ -68,7 +68,9 @@ Methods:
         elif constructor_callable is None:
             parsable_factory = PageResult
         else:
-            raise ValueError('One of the constructor_callable or the PageResult type parameter is required.')
+            raise ValueError(
+                'One of the constructor_callable or the PageResult type parameter is required.'
+            )
         self.parsable_factory = parsable_factory
         self.pause_index = 0
         self.headers: HeadersCollection = HeadersCollection()

--- a/src/msgraph_core/tasks/page_iterator.py
+++ b/src/msgraph_core/tasks/page_iterator.py
@@ -141,7 +141,6 @@ Methods:
         if self.current_page is not None and not self.current_page.odata_next_link:
             return None
         response = await self.fetch_next_page()
-        print(f"Response - {type(response)}")
         page: PageResult = PageResult(response.odata_next_link, response.value)  # type: ignore
         return page
 


### PR DESCRIPTION
## Overview

Remove the dangling printouts like
`Response - <class 'msgraph.generated.models.calendar_permission_collection_response.CalendarPermissionCollectionResponse'>`


### Demo

use the `class PageIterator` and call `next()` for example by using `iterate()`.

## Testing Instructions

I think there is no testing needed