### PR TITLE
ci: removes outdated branch policy for dev branch

### DIFF
--- a/.github/policies/msgraph-sdk-python-core-branch-protection.yml
+++ b/.github/policies/msgraph-sdk-python-core-branch-protection.yml
@@ -7,43 +7,6 @@ resource: repository
 configuration:
   branchProtectionRules:
 
-  - branchNamePattern: dev
-    # This branch pattern applies to the following branches as of 06/12/2023 11:37:28:
-    # dev
-
-    # Specifies whether this branch can be deleted. boolean
-    allowsDeletions: false
-    # Specifies whether forced pushes are allowed on this branch. boolean
-    allowsForcePushes: false
-    # Specifies whether new commits pushed to the matching branches dismiss pull request review approvals. boolean
-    dismissStaleReviews: true
-    # Specifies whether admins can overwrite branch protection. boolean
-    isAdminEnforced: false
-    # Indicates whether "Require a pull request before merging" is enabled. boolean
-    requiresPullRequestBeforeMerging: true
-    # Specifies the number of pull request reviews before merging. int (0-6). Should be null/empty if PRs are not required
-    requiredApprovingReviewsCount: 1
-    # Require review from Code Owners. Requires requiredApprovingReviewsCount. boolean
-    requireCodeOwnersReview: true
-    # Are commits required to be signed. boolean. TODO: all contributors must have commit signing on local machines.
-    requiresCommitSignatures: false
-    # Are conversations required to be resolved before merging? boolean
-    requiresConversationResolution: true
-    # Are merge commits prohibited from being pushed to this branch. boolean
-    requiresLinearHistory: false
-    # Required status checks to pass before merging. Values can be any string, but if the value does not correspond to any 
-    # existing status check, the status check will be stuck on pending for status since nothing exists to push an actual status
-    requiredStatusChecks:
-    - CodeQL
-    - check-build-matrix
-    - license/cla
-    # Require branches to be up to date before merging. Requires requiredStatusChecks. boolean
-    requiresStrictStatusChecks: true
-    # Indicates whether there are restrictions on who can push. boolean. Should be set with whoCanPush.
-    restrictsPushes: false
-    # Restrict who can dismiss pull request reviews. boolean
-    restrictsReviewDismissals: false
-
   - branchNamePattern: main
     # This branch pattern applies to the following branches as of 01/12/2024 13:14:28:
     # main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main, dev]
+    branches: [main]
   workflow_call:
 
 jobs:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [main, dev]
+    branches: [main]
   schedule:
     - cron: "32 11 * * 6"
 

--- a/.github/workflows/conflicting-pr-label.yml
+++ b/.github/workflows/conflicting-pr-label.yml
@@ -6,10 +6,10 @@ name: PullRequestConflicting
 # events but only for the master branch
 on:
   push:
-    branches: [main, dev]
+    branches: [main]
   pull_request:
     types: [synchronize]
-    branches: [main, dev]
+    branches: [main]
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
Signed-off-by: Vincent Biret <vibiret@microsoft.com>
