### PR TITLE
Removes unused poetry config to unblock Dependabot updates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,3 @@ push = false
 [tool.bumpver.file_patterns]
 "pyproject.toml" = ['current_version = "{version}"', 'version = "{version}"']
 "src/msgraph_core/_constants.py" = ["{version}"]
-
-[tool.poetry.packages]
-include = ["src/msgraph_core"]


### PR DESCRIPTION
Some required parameters e.g. package name, version, authors for `poetry`'s configuration are currently missing causing dependabot runs to [fail](https://github.com/microsoftgraph/msgraph-sdk-python-core/network/updates/920958744) for this repository causing older versions of dependencies to be used by customers.

We could add a complete poetry config to fix the issue, but we'd have duplicate config for versions, pkg name etc.
This PR proposes dropping the poetry config since we're not using poetry to manage dependencies, builds/releases.

[Poetry required config ref](https://python-poetry.org/docs/pyproject/)