### PR TITLE
fix: bump kiota dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -145,11 +145,11 @@ httpx[http2]==0.28.1
 
 hyperframe==6.1.0 ; python_full_version >= '3.6.1'
 
-microsoft-kiota-abstractions==1.9.1
+microsoft-kiota-abstractions==1.9.2
 
-microsoft-kiota-authentication-azure==1.9.1
+microsoft-kiota-authentication-azure==1.9.2
 
-microsoft-kiota-http==1.9.1
+microsoft-kiota-http==1.9.2
 
 multidict==6.1.0 ; python_version >= '3.7'
 


### PR DESCRIPTION
subject to publishing workflow https://github.com/microsoft/kiota-python/actions/runs/13174230748