### PR TITLE
Fix add_batch_request_item

### DIFF
--- a/src/msgraph_core/requests/batch_request_content_collection.py
+++ b/src/msgraph_core/requests/batch_request_content_collection.py
@@ -26,7 +26,7 @@ class BatchRequestContentCollection:
             request (BatchRequestItem): The request item to add.
         """
         if len(self.current_batch.requests) >= self.max_requests_per_batch:
-            self.batches.append(self.current_batch.finalize())
+            self.current_batch.finalize()
             self.current_batch = BatchRequestContent()
             self.batches.append(self.current_batch)
         self.current_batch.add_request(request.id, request)

--- a/src/msgraph_core/requests/batch_request_content_collection.py
+++ b/src/msgraph_core/requests/batch_request_content_collection.py
@@ -16,8 +16,8 @@ class BatchRequestContentCollection:
 
         """
         self.max_requests_per_batch = BatchRequestContent.MAX_REQUESTS
-        self.batches: list[BatchRequestContent] = []
         self.current_batch: BatchRequestContent = BatchRequestContent()
+        self.batches: list[BatchRequestContent] = [self.current_batch]
 
     def add_batch_request_item(self, request: BatchRequestItem) -> None:
         """
@@ -28,8 +28,8 @@ class BatchRequestContentCollection:
         if len(self.current_batch.requests) >= self.max_requests_per_batch:
             self.batches.append(self.current_batch.finalize())
             self.current_batch = BatchRequestContent()
+            self.batches.append(self.current_batch)
         self.current_batch.add_request(request.id, request)
-        self.batches.append(self.current_batch)
 
     def remove_batch_request_item(self, request_id: str) -> None:
         """
@@ -49,16 +49,30 @@ class BatchRequestContentCollection:
             Optional[BatchRequestContent]: A new batch with failed requests.
         """
         # Use IDs to get response status codes, generate new batch with failed requests
-        batch_with_failed_responses: Optional[BatchRequestContent] = BatchRequestContent()
+        batch_with_failed_responses: Optional[BatchRequestContent] = (
+            BatchRequestContent()
+        )
         for batch in self.batches:
             for request in batch.requests:
-                if request.status_code not in [ # type: ignore # Method should be deprecated
-                    200, 201, 202, 203, 204, 205, 206, 207, 208, 226
-                ]:
+                if (
+                    request.status_code
+                    not in [  # type: ignore # Method should be deprecated
+                        200,
+                        201,
+                        202,
+                        203,
+                        204,
+                        205,
+                        206,
+                        207,
+                        208,
+                        226,
+                    ]
+                ):
                     if batch_with_failed_responses is not None:
                         batch_with_failed_responses.add_request(
                             request.id,  # type: ignore # Bug. Method should be deprecated
-                            request  # type: ignore
+                            request,  # type: ignore
                         )
                     else:
                         raise ValueError("batch_with_failed_responses is None")

--- a/src/msgraph_core/requests/batch_request_content_collection.py
+++ b/src/msgraph_core/requests/batch_request_content_collection.py
@@ -49,30 +49,16 @@ class BatchRequestContentCollection:
             Optional[BatchRequestContent]: A new batch with failed requests.
         """
         # Use IDs to get response status codes, generate new batch with failed requests
-        batch_with_failed_responses: Optional[BatchRequestContent] = (
-            BatchRequestContent()
-        )
+        batch_with_failed_responses: Optional[BatchRequestContent] = BatchRequestContent()
         for batch in self.batches:
             for request in batch.requests:
-                if (
-                    request.status_code
-                    not in [  # type: ignore # Method should be deprecated
-                        200,
-                        201,
-                        202,
-                        203,
-                        204,
-                        205,
-                        206,
-                        207,
-                        208,
-                        226,
-                    ]
-                ):
+                if request.status_code not in [ # type: ignore # Method should be deprecated
+                    200, 201, 202, 203, 204, 205, 206, 207, 208, 226
+                ]:
                     if batch_with_failed_responses is not None:
                         batch_with_failed_responses.add_request(
                             request.id,  # type: ignore # Bug. Method should be deprecated
-                            request,  # type: ignore
+                            request  # type: ignore
                         )
                     else:
                         raise ValueError("batch_with_failed_responses is None")

--- a/tests/requests/test_batch_request_content_collection.py
+++ b/tests/requests/test_batch_request_content_collection.py
@@ -1,0 +1,44 @@
+import pytest
+from io import BytesIO
+from kiota_abstractions.request_information import RequestInformation
+from msgraph_core.requests.batch_request_item import BatchRequestItem
+from msgraph_core.requests.batch_request_content_collection import BatchRequestContentCollection
+from kiota_abstractions.headers_collection import HeadersCollection as RequestHeaders
+
+
+@pytest.fixture
+def batch_request_content_collection():
+    return BatchRequestContentCollection()
+
+
+@pytest.fixture
+def request_info():
+    request_info = RequestInformation()
+    request_info.http_method = "GET"
+    request_info.url = "https://graph.microsoft.com/v1.0/me"
+    request_info.headers = RequestHeaders()
+    request_info.headers.add("Content-Type", "application/json")
+    request_info.content = BytesIO(b'{"key": "value"}')
+    return request_info
+
+
+@pytest.fixture
+def batch_request_item1(request_info):
+    return BatchRequestItem(request_information=request_info, id="1")
+
+
+@pytest.fixture
+def batch_request_item2(request_info):
+    return BatchRequestItem(request_information=request_info, id="2")
+
+
+def test_init_batches(batch_request_content_collection):
+    assert len(batch_request_content_collection.batches) == 1
+    assert batch_request_content_collection.current_batch is not None
+
+
+def test_add_batch_request_item(batch_request_content_collection, batch_request_item1, batch_request_item2):
+    batch_request_content_collection.add_batch_request_item(batch_request_item1)
+    batch_request_content_collection.add_batch_request_item(batch_request_item2)
+    assert len(batch_request_content_collection.batches) == 1
+    assert len(batch_request_content_collection.current_batch.requests) == 2


### PR DESCRIPTION
## Overview

the same batch was getting appended to the batches everytime a BatchRequestItem was added to a collection, so in sequence adding requests 1, 2 and 3, the batches would look like:
[[1]],
[[1,2],[1,2]]
[[1,2,3],[1,2,3],[1,2,3]]
etc