### PR TITLE
fix BatchRequestItem now properly serializes the header and body fields

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -151,6 +151,8 @@ microsoft-kiota-authentication-azure==1.9.3
 
 microsoft-kiota-http==1.9.3
 
+microsoft-kiota-serialization-json==1.9.3
+
 multidict==6.5.0 ; python_version >= '3.7'
 
 uritemplate==4.2.0 ; python_version >= '3.6'

--- a/src/msgraph_core/requests/batch_request_item.py
+++ b/src/msgraph_core/requests/batch_request_item.py
@@ -259,7 +259,7 @@ class BatchRequestItem(Parsable):
         writer.write_str_value('url', self.url)
         writer.write_collection_of_primitive_values('depends_on', self._depends_on)
         writer.write_additional_data_value(
-            {'headers': self._headers} # need proper method to serialize dicts
+            {'headers': self._headers}  # need proper method to serialize dicts
         )
         if self._body:
             json_object = json.loads(self._body)
@@ -267,7 +267,7 @@ class BatchRequestItem(Parsable):
             # /$batch API expects JSON object or base 64 encoded value for the body
             if is_json_string:
                 writer.write_additional_data_value(
-                    {'body': json_object} # need proper method to serialize dicts
+                    {'body': json_object}  # need proper method to serialize dicts
                 )
             else:
                 writer.write_str_value('body', base64.b64encode(self._body).decode('utf-8'))

--- a/src/msgraph_core/requests/batch_request_item.py
+++ b/src/msgraph_core/requests/batch_request_item.py
@@ -258,19 +258,16 @@ class BatchRequestItem(Parsable):
         writer.write_str_value('method', self.method)
         writer.write_str_value('url', self.url)
         writer.write_collection_of_primitive_values('depends_on', self._depends_on)
-        writer.write_collection_of_object_values(
-            'headers',
-            self._headers  # type: ignore # need method to serialize dicts
+        writer.write_additional_data_value(
+            {'headers': self._headers} # need proper method to serialize dicts
         )
         if self._body:
             json_object = json.loads(self._body)
             is_json_string = json_object and isinstance(json_object, dict)
             # /$batch API expects JSON object or base 64 encoded value for the body
             if is_json_string:
-                writer.write_collection_of_object_values(   # type: ignore
-                    # need method to serialize dicts
-                    'body',
-                    json_object
+                writer.write_additional_data_value(
+                    {'body': json_object} # need proper method to serialize dicts
                 )
             else:
                 writer.write_str_value('body', base64.b64encode(self._body).decode('utf-8'))


### PR DESCRIPTION
## Overview

The batch request item serialization does not currently work for the header and body fields. For both of them, a dictionary is being passed to the write_collection_of_object_values, which is supposed to be given a list of parsable objects. An ignore type annotation is being given to silence the error.

I've replaced the method with write_additional_data_value. This method accepts a dictionary of arbitrary types, so it's able to handle the deserialized json string for the body.

### Demo

### Notes

The write_additional_data_value is not intended to be used in this way, and is usually used to handle excess fields that may be included in the body of a request, but are not part of the parsable model class. A dedicated method for serializing dicts is probably needed.

## Testing Instructions
