### PR TITLE
Fix/graph client factory initializion

### DIFF
--- a/src/msgraph_core/graph_client_factory.py
+++ b/src/msgraph_core/graph_client_factory.py
@@ -22,8 +22,7 @@ class GraphClientFactory():
     """
 
     @staticmethod
-    def create_with_default_middleware( # type: ignore
-        # Breaking change to remove KiotaClientFactory as base class
+    def create_with_default_middleware(
         api_version: APIVersion = APIVersion.v1,
         client: Optional[httpx.AsyncClient] = None,
         host: NationalClouds = NationalClouds.Global,
@@ -50,15 +49,16 @@ class GraphClientFactory():
         """
         if client is None:
             client = KiotaClientFactory.get_default_client()
-            client.base_url = GraphClientFactory._get_base_url(host, api_version)  # type: ignore
+            client.base_url = GraphClientFactory._get_base_url(
+                host, api_version)
+
         middleware = KiotaClientFactory.get_default_middleware(options)
         telemetry_handler = GraphClientFactory._get_telemetry_handler(options)
         middleware.append(telemetry_handler)
         return GraphClientFactory._load_middleware_to_client(client, middleware)
 
     @staticmethod
-    def create_with_custom_middleware( # type: ignore
-        # Breaking change to remove Kiota client factory as base class
+    def create_with_custom_middleware(
         middleware: Optional[list[BaseMiddleware]],
         api_version: APIVersion = APIVersion.v1,
         client: Optional[httpx.AsyncClient] = None,
@@ -83,7 +83,9 @@ class GraphClientFactory():
         """
         if client is None:
             client = KiotaClientFactory.get_default_client()
-            client.base_url = GraphClientFactory._get_base_url(host, api_version)  # type: ignore
+            client.base_url = GraphClientFactory._get_base_url(
+                host, api_version)
+
         return GraphClientFactory._load_middleware_to_client(client, middleware)
 
     @staticmethod
@@ -124,7 +126,7 @@ class GraphClientFactory():
                     mounts[pattern
                            ] = GraphClientFactory._replace_transport_with_custom_graph_transport(
                                transport, middleware
-                           )
+                    )
             client._mounts = dict(sorted(mounts.items()))
         return client
 

--- a/src/msgraph_core/graph_client_factory.py
+++ b/src/msgraph_core/graph_client_factory.py
@@ -37,7 +37,7 @@ class GraphClientFactory():
             This is only used if the client parameter is None.
             client (Optional[httpx.AsyncClient]]): The httpx.AsyncClient instance to be used.
             Defaults to None.
-            When None, a default client will be created with the base url set to https://{host}/{api_version}.
+            When None, a client will be created with base url set to https://{host}/{api_version}.
             host (NationalClouds): The national clound endpoint to be used.
             Defaults to NationalClouds.Global.
             This is only used if the client parameter is None.
@@ -66,16 +66,16 @@ class GraphClientFactory():
         """Applies a custom middleware chain to the HTTP Client
 
         Args:
-            middleware(Optional[list[BaseMiddleware]]): Custom middleware list that will be used to create
-            a middleware pipeline. The middleware should be arranged in the order in which they will
-            modify the request.
+            middleware(Optional[list[BaseMiddleware]]): Custom middleware list that will be used to
+            create a middleware pipeline. The middleware should be arranged in the order in which 
+            they will modify the request.
             Defaults to None,
             api_version (APIVersion): The Graph API version to be used. 
             Defaults to APIVersion.v1.
             This is only used if the client parameter is None.
             client (Optional[httpx.AsyncClient]): The httpx.AsyncClient instance to be used.
             Defaults to None.
-            When None, a default client will be created with the base url set to https://{host}/{api_version}.
+            When None, a client will be created with base url set to https://{host}/{api_version}.
             host (NationalClouds): The national cloud endpoint to be used.
             Defaults to NationalClouds.Global.
             This is only used if the client parameter is None.

--- a/src/msgraph_core/graph_client_factory.py
+++ b/src/msgraph_core/graph_client_factory.py
@@ -49,8 +49,7 @@ class GraphClientFactory():
         """
         if client is None:
             client = KiotaClientFactory.get_default_client()
-            client.base_url = GraphClientFactory._get_base_url(
-                host, api_version)
+            client.base_url = GraphClientFactory._get_base_url(host, api_version)
 
         middleware = KiotaClientFactory.get_default_middleware(options)
         telemetry_handler = GraphClientFactory._get_telemetry_handler(options)
@@ -83,8 +82,7 @@ class GraphClientFactory():
         """
         if client is None:
             client = KiotaClientFactory.get_default_client()
-            client.base_url = GraphClientFactory._get_base_url(
-                host, api_version)
+            client.base_url = GraphClientFactory._get_base_url(host, api_version)
 
         return GraphClientFactory._load_middleware_to_client(client, middleware)
 
@@ -126,7 +124,7 @@ class GraphClientFactory():
                     mounts[pattern
                            ] = GraphClientFactory._replace_transport_with_custom_graph_transport(
                                transport, middleware
-                    )
+                           )
             client._mounts = dict(sorted(mounts.items()))
         return client
 

--- a/src/msgraph_core/graph_client_factory.py
+++ b/src/msgraph_core/graph_client_factory.py
@@ -16,7 +16,7 @@ from .middleware import AsyncGraphTransport, GraphTelemetryHandler
 from .middleware.options import GraphTelemetryHandlerOption
 
 
-class GraphClientFactory(KiotaClientFactory):
+class GraphClientFactory():
     """Constructs httpx.AsyncClient instances configured with either custom or default
     pipeline of graph specific middleware.
     """
@@ -35,10 +35,13 @@ class GraphClientFactory(KiotaClientFactory):
         Args:
             api_version (APIVersion): The Graph API version to be used.
             Defaults to APIVersion.v1.
-            client  (httpx.AsyncClient): The httpx.AsyncClient instance to be used.
-            Defaults to KiotaClientFactory.get_default_client().
+            This is only used if the client parameter is None.
+            client (Optional[httpx.AsyncClient]]): The httpx.AsyncClient instance to be used.
+            Defaults to None.
+            When None, a default client will be created with the base url set to https://{host}/{api_version}.
             host (NationalClouds): The national clound endpoint to be used.
             Defaults to NationalClouds.Global.
+            This is only used if the client parameter is None.
             options (Optional[dict[str, RequestOption]]): The request options to use when
             instantiating default middleware. Defaults to dict[str, RequestOption]=None.
 
@@ -47,7 +50,7 @@ class GraphClientFactory(KiotaClientFactory):
         """
         if client is None:
             client = KiotaClientFactory.get_default_client()
-        client.base_url = GraphClientFactory._get_base_url(host, api_version)  # type: ignore
+            client.base_url = GraphClientFactory._get_base_url(host, api_version)  # type: ignore
         middleware = KiotaClientFactory.get_default_middleware(options)
         telemetry_handler = GraphClientFactory._get_telemetry_handler(options)
         middleware.append(telemetry_handler)
@@ -64,19 +67,23 @@ class GraphClientFactory(KiotaClientFactory):
         """Applies a custom middleware chain to the HTTP Client
 
         Args:
-            middleware(list[BaseMiddleware]): Custom middleware list that will be used to create
+            middleware(Optional[list[BaseMiddleware]]): Custom middleware list that will be used to create
             a middleware pipeline. The middleware should be arranged in the order in which they will
             modify the request.
-            api_version (APIVersion): The Graph API version to be used.
+            Defaults to None,
+            api_version (APIVersion): The Graph API version to be used. 
             Defaults to APIVersion.v1.
-            client  (httpx.AsyncClient): The httpx.AsyncClient instance to be used.
-            Defaults to KiotaClientFactory.get_default_client().
-            host (NationalClouds): The national clound endpoint to be used.
+            This is only used if the client parameter is None.
+            client (Optional[httpx.AsyncClient]): The httpx.AsyncClient instance to be used.
+            Defaults to None.
+            When None, a default client will be created with the base url set to https://{host}/{api_version}.
+            host (NationalClouds): The national cloud endpoint to be used.
             Defaults to NationalClouds.Global.
+            This is only used if the client parameter is None.
         """
         if client is None:
             client = KiotaClientFactory.get_default_client()
-        client.base_url = GraphClientFactory._get_base_url(host, api_version)  # type: ignore
+            client.base_url = GraphClientFactory._get_base_url(host, api_version)  # type: ignore
         return GraphClientFactory._load_middleware_to_client(client, middleware)
 
     @staticmethod

--- a/src/msgraph_core/requests/batch_request_item.py
+++ b/src/msgraph_core/requests/batch_request_item.py
@@ -3,11 +3,11 @@ import enum
 import json
 import re
 import urllib.request
-from deprecated import deprecated
 from io import BytesIO
 from typing import Any, Optional, Union
 from urllib.parse import urlparse
 from uuid import uuid4
+from deprecated import deprecated
 
 from kiota_abstractions.headers_collection import HeadersCollection as RequestHeaders
 from kiota_abstractions.method import Method


### PR DESCRIPTION
## Overview

Updates the GraphClientFactory so that the baseUrl of the httpClient is only set when creating a new httpClient. This ensures that any client which has previously set a baseUrl and is adding middleware to the client will not have the existing baseUrl set

Related to  https://github.com/microsoftgraph/msgraph-beta-sdk-python/issues/743
