### PR TITLE
fix: remove MIT License from project classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "License :: OSI Approved :: MIT License",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Outdated classifier, must be removed for publication