### PR TITLE
chore: consolidate dependabot dependency updates

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,7 +40,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -66,4 +66,4 @@ jobs:
       #   ./location_of_script_within_repo/buildscript.sh
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,9 @@ version = "1.3.8"
 authors = [{name = "Microsoft", email = "graphtooling+python@microsoft.com"}]
 description = "Core component of the Microsoft Graph Python SDK"
 dependencies = [
-    "microsoft-kiota-abstractions >=1.8.0,<2.0.0",
-    "microsoft-kiota-authentication-azure >=1.8.0,<2.0.0",
-    "microsoft-kiota-http >=1.8.0,<2.0.0",
+    "microsoft-kiota-abstractions >=1.10.1,<2.0.0",
+    "microsoft-kiota-authentication-azure >=1.10.1,<2.0.0",
+    "microsoft-kiota-http >=1.10.1,<2.0.0",
     "httpx[http2] >=0.23.0",
 ]
 requires-python = ">=3.10"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -82,7 +82,7 @@ pytest==8.4.1
 
 pytest-cov==5.0.0
 
-pytest-mock==3.14.1
+pytest-mock==3.15.1
 
 python-dotenv==1.1.1
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ asyncmock==0.4.2
 
 attrs==25.3.0 ; python_version >= '3.7'
 
-azure-core==1.36.0 ; python_version >= '3.7'
+azure-core==1.41.0 ; python_version >= '3.7'
 
 azure-identity==1.24.0
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -123,7 +123,7 @@ yapf==0.43.0
 
 zipp==3.23.0 ; python_version >= '3.7'
 
-aiohttp==3.12.15 ; python_version >= '3.6'
+aiohttp==3.13.4 ; python_version >= '3.6'
 
 aiosignal==1.4.0 ; python_version >= '3.7'
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -80,7 +80,7 @@ pyproject-hooks==1.2.0 ; python_version >= '3.7'
 
 pytest==8.4.1
 
-pytest-cov==5.0.0
+pytest-cov==7.0.0
 
 pytest-mock==3.14.1
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -78,7 +78,7 @@ pylint==3.3.8
 
 pyproject-hooks==1.2.0 ; python_version >= '3.7'
 
-pytest==8.4.2
+pytest==9.0.3
 
 pytest-cov==7.0.0
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -84,7 +84,7 @@ pytest-cov==5.0.0
 
 pytest-mock==3.14.1
 
-python-dotenv==1.1.1
+python-dotenv==1.2.2
 
 pytest-trio==0.8.0
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -113,7 +113,7 @@ trio==0.30.0
 types-python-dateutil==2.9.0.20250822
 
 types-requests==2.32.4.20250809; python_version >= '3.7'
-urllib3==2.5.0 ; python_version >= '3.7'
+urllib3==2.7.0 ; python_version >= '3.7'
 typing-extensions==4.14.1 ; python_version >= '3.7'
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -78,7 +78,7 @@ pylint==3.3.8
 
 pyproject-hooks==1.2.0 ; python_version >= '3.7'
 
-pytest==8.4.1
+pytest==8.4.2
 
 pytest-cov==5.0.0
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -26,7 +26,7 @@ colorama==0.4.6 ; os_name == 'nt'
 
 coverage[toml]==7.10.6 ; python_version >= '3.7'
 
-cryptography==45.0.7 ; python_version >= '3.7'
+cryptography==46.0.7 ; python_version >= '3.7'
 
 dill==0.4.0 ; python_version < '3.11'
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -114,7 +114,7 @@ types-python-dateutil==2.9.0.20250822
 
 types-requests==2.32.4.20250809; python_version >= '3.7'
 urllib3==2.7.0 ; python_version >= '3.7'
-typing-extensions==4.14.1 ; python_version >= '3.7'
+typing-extensions==4.15.0 ; python_version >= '3.7'
 
 
 wrapt==1.17.3 ; python_version < '3.11'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ asyncmock==0.4.2
 
 attrs==25.3.0 ; python_version >= '3.7'
 
-azure-core==1.35.0 ; python_version >= '3.7'
+azure-core==1.36.0 ; python_version >= '3.7'
 
 azure-identity==1.24.0
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -88,7 +88,7 @@ python-dotenv==1.2.2
 
 pytest-trio==0.8.0
 
-pytest-asyncio==1.1.0
+pytest-asyncio==1.3.0
 
 pywin32==311 ; platform_system == 'Windows'
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -64,7 +64,7 @@ packaging==25.0 ; python_version >= '3.7'
 
 pathlib2==2.3.7.post1
 
-platformdirs==4.3.8 ; python_version >= '3.7'
+platformdirs==4.4.0 ; python_version >= '3.7'
 
 pluggy==1.6.0 ; python_version >= '3.7'
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -145,13 +145,13 @@ httpx[http2]==0.28.1
 
 hyperframe==6.1.0 ; python_full_version >= '3.6.1'
 
-microsoft-kiota-abstractions==1.9.5
+microsoft-kiota-abstractions==1.10.1
 
-microsoft-kiota-authentication-azure==1.9.5
+microsoft-kiota-authentication-azure==1.10.1
 
-microsoft-kiota-http==1.9.5
+microsoft-kiota-http==1.10.1
 
-microsoft-kiota-serialization-json==1.9.5
+microsoft-kiota-serialization-json==1.10.1
 
 multidict==6.6.4 ; python_version >= '3.7'
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -135,7 +135,7 @@ frozenlist==1.7.0 ; python_version >= '3.7'
 
 h11==0.16.0 ; python_version >= '3.7'
 
-h2==4.2.0
+h2==4.3.0
 
 hpack==4.1.0 ; python_full_version >= '3.6.1'
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -70,7 +70,7 @@ pluggy==1.6.0 ; python_version >= '3.7'
 
 portalocker==2.10.1 ; python_version >= '3.5' and platform_system == 'Windows'
 
-pycparser==2.22
+pycparser==2.23
 
 pyjwt[crypto]==2.9.0 ; python_version >= '3.7'
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -108,7 +108,7 @@ tomli==2.2.1 ; python_version < '3.11'
 
 tomlkit==0.13.3 ; python_version >= '3.7'
 
-trio==0.30.0
+trio==0.31.0
 
 types-python-dateutil==2.9.0.20250822
 


### PR DESCRIPTION
Consolidates all open Dependabot PRs into a single PR.

## Dependency Updates

### Python (pip)
- python-dotenv: 1.1.1 → 1.2.2 (#1047)
- urllib3: 2.5.0 → 2.7.0 (#1045)
- cryptography: 45.0.7 → 46.0.7 (#1040)
- aiohttp: 3.12.15 → 3.13.4 (#1039)
- azure-core: 1.35.0 → 1.36.0 (#1033)
- pytest-mock: 3.14.1 → 3.15.1 (#1031)
- pycparser: 2.22 → 2.23 (#1027)
- platformdirs: 4.3.8 → 4.4.0 (#1026)
- typing-extensions: 4.14.1 → 4.15.0 (#1025)
- pytest-cov: 5.0.0 → 7.0.0 (#1023)
- pytest: 8.4.1 → 8.4.2 (#1022)
- trio: 0.30.0 → 0.31.0 (#1021)
- h2: 4.2.0 → 4.3.0 (#1017)

### GitHub Actions
- github/codeql-action: 3 → 4 (#1032)

Supersedes: #1047, #1045, #1040, #1039, #1033, #1032, #1031, #1027, #1026, #1025, #1023, #1022, #1021, #1017