### PR TITLE
chore(deps): consolidate all dependabot updates

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2.4.0
+        uses: dependabot/fetch-metadata@v3.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/project-auto-add.yml
+++ b/.github/workflows/project-auto-add.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.GRAPHBOT_APP_ID }}
           private-key: ${{ secrets.GRAPHBOT_APP_PEM }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build package
         run: python -m build
       - name: Publish package
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/release-please-gha.yml
+++ b/.github/workflows/release-please-gha.yml
@@ -29,7 +29,7 @@ jobs:
           private-key: ${{ secrets.RELEASE_PLEASE_TOKEN_PROVIDER_PEM }}
 
       - name: Release Please
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@v5
         with:
           token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json

--- a/.github/workflows/release-please-gha.yml
+++ b/.github/workflows/release-please-gha.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.RELEASE_PLEASE_TOKEN_PROVIDER_APP_ID }}
           private-key: ${{ secrets.RELEASE_PLEASE_TOKEN_PROVIDER_PEM }}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -161,4 +161,4 @@ yarl==1.20.1 ; python_version >= '3.7'
 
 deprecated==1.2.18
 
-types-Deprecated==1.2.15.20250304
+types-Deprecated==1.3.1.20260519

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -157,7 +157,7 @@ multidict==6.6.4 ; python_version >= '3.7'
 
 uritemplate==4.2.0 ; python_version >= '3.6'
 
-yarl==1.20.1 ; python_version >= '3.7'
+yarl==1.24.2 ; python_version >= '3.7'
 
 deprecated==1.2.18
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -92,7 +92,7 @@ pytest-asyncio==1.3.0
 
 pywin32==311 ; platform_system == 'Windows'
 
-requests==2.32.5 ; python_version >= '3.7'
+requests==2.33.0 ; python_version >= '3.7'
 
 setuptools==80.9.0
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -72,7 +72,7 @@ portalocker==2.10.1 ; python_version >= '3.5' and platform_system == 'Windows'
 
 pycparser==2.23
 
-pyjwt[crypto]==2.9.0 ; python_version >= '3.7'
+pyjwt[crypto]==2.12.0 ; python_version >= '3.7'
 
 pylint==3.3.8
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -123,7 +123,7 @@ yapf==0.43.0
 
 zipp==3.23.0 ; python_version >= '3.7'
 
-aiohttp==3.13.4 ; python_version >= '3.6'
+aiohttp==3.13.5 ; python_version >= '3.6'
 
 aiosignal==1.4.0 ; python_version >= '3.7'
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -131,7 +131,7 @@ anyio==4.10.0 ; python_version >= '3.7'
 
 async-timeout==5.0.1 ; python_version >= '3.6'
 
-frozenlist==1.7.0 ; python_version >= '3.7'
+frozenlist==1.8.0 ; python_version >= '3.7'
 
 h11==0.16.0 ; python_version >= '3.7'
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -50,7 +50,7 @@ mccabe==0.7.0 ; python_version >= '3.6'
 
 mock==5.2.0 ; python_version >= '3.6'
 
-msal==1.33.0
+msal==1.36.0
 
 msal-extensions==1.3.1
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -74,7 +74,7 @@ pycparser==2.23
 
 pyjwt[crypto]==2.9.0 ; python_version >= '3.7'
 
-pylint==3.3.8
+pylint==4.0.5
 
 pyproject-hooks==1.2.0 ; python_version >= '3.7'
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -36,7 +36,7 @@ idna==3.10 ; python_version >= '3.5'
 
 importlib-metadata==7.1.0 ; python_version >= '3.7'
 
-iniconfig==2.1.0 ; python_version >= '3.7'
+iniconfig==2.3.0 ; python_version >= '3.7'
 
 isort==6.0.1
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -32,7 +32,7 @@ dill==0.4.0 ; python_version < '3.11'
 
 exceptiongroup==1.3.0 ; python_version < '3.11'
 
-idna==3.10 ; python_version >= '3.5'
+idna==3.15 ; python_version >= '3.5'
 
 importlib-metadata==7.1.0 ; python_version >= '3.7'
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -121,7 +121,7 @@ wrapt==1.17.3 ; python_version < '3.11'
 
 yapf==0.43.0
 
-zipp==3.23.0 ; python_version >= '3.7'
+zipp==4.1.0 ; python_version >= '3.7'
 
 aiohttp==3.13.4 ; python_version >= '3.6'
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -110,7 +110,7 @@ tomlkit==0.13.3 ; python_version >= '3.7'
 
 trio==0.31.0
 
-types-python-dateutil==2.9.0.20250822
+types-python-dateutil==2.9.0.20260518
 
 types-requests==2.32.4.20250809; python_version >= '3.7'
 urllib3==2.7.0 ; python_version >= '3.7'


### PR DESCRIPTION
This PR consolidates all 16 open Dependabot PRs into a single update.

## Python dependency updates (dev)
- pylint: 3.3.8 → 4.0.5 (#1051)
- msal: 1.33.0 → 1.36.0 (#1052)
- types-python-dateutil: 2.9.0.20250822 → 2.9.0.20260518 (#1053)
- frozenlist: 1.7.0 → 1.8.0 (#1054)
- zipp: 3.23.0 → 4.1.0 (#1055)
- aiohttp: 3.13.4 → 3.13.5 (#1056)
- yarl: 1.20.1 → 1.24.2 (#1057)
- iniconfig: 2.1.0 → 2.3.0 (#1058)
- types-deprecated: 1.2.15.20250304 → 1.3.1.20260519 (#1059)
- idna: 3.10 → 3.15 (#1064)
- pyjwt: 2.9.0 → 2.12.0 (#1065)
- requests: 2.32.5 → 2.33.0 (#1066)

## GitHub Actions updates
- dependabot/fetch-metadata: 2.4.0 → 3.1.0 (#1060)
- actions/create-github-app-token: 2 → 3 (#1061)
- pypa/gh-action-pypi-publish: 1.13.0 → 1.14.0 (#1062)
- googleapis/release-please-action: 4 → 5 (#1063)

Supersedes: #1051, #1052, #1053, #1054, #1055, #1056, #1057, #1058, #1059, #1060, #1061, #1062, #1063, #1064, #1065, #1066