### PR TITLE
Fix/daily ci pool image

### DIFF
--- a/.azure-pipelines/daily-ci-build.yml
+++ b/.azure-pipelines/daily-ci-build.yml
@@ -21,6 +21,7 @@ extends:
   parameters:
     pool:
       name: Azure-Pipelines-1ESPT-ExDShared
+      image: ubuntu-latest
       os: linux
     sdl:
       sourceAnalysisPool:
@@ -47,11 +48,17 @@ extends:
                 inputs:
                   versionSpec: '3.12'
 
+              - task: PipAuthenticate@1
+                displayName: Authenticate with Azure Artifacts
+                inputs:
+                  artifactFeeds: Graph Developer Experiences/GraphDeveloperExperiences_Public
+                  onlyAddExtraIndex: false
+
               - script: python -m pip install --upgrade pip
                 displayName: Upgrade pip
                 workingDirectory: $(Build.SourcesDirectory)
 
-              - script: pip install -e ".[dev]"
+              - script: pip install -r requirements-dev.txt
                 displayName: Install dependencies
                 workingDirectory: $(Build.SourcesDirectory)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
--i https://pypi.org/simple
 
 async-generator==1.10 ; python_version >= '3.5'
 


### PR DESCRIPTION
The daily CI build was failing with:

 - 1ES PT Error: The os property specified in the pool does not match with the actual image — missing image property in pool config
 - pip install failures due to network isolation on the 1ES hosted agent

Changes

 - Added image: ubuntu-latest to the pool configuration to satisfy 1ES Pipeline Template requirements
 - Added PipAuthenticate@1 task with Graph Developer Experiences/GraphDeveloperExperiences_Public feed as the primary index for CFS-compliant dependency resolution
 