### PR TITLE
fix: HTTP/1.1 requests with truncated kernel versions

### DIFF
--- a/src/msgraph_core/middleware/telemetry.py
+++ b/src/msgraph_core/middleware/telemetry.py
@@ -115,7 +115,7 @@ class GraphTelemetryHandler(BaseMiddleware):
         """
         system = platform.system()
         version = platform.version()
-        host_os = f'{system} {version}'
+        host_os = f'{system} {version}'.strip()
         request.headers.update({'HostOs': host_os})
 
     def _add_runtime_environment_header(self, request) -> None:


### PR DESCRIPTION
## Overview

This PR fixes a bug where requests cannot be sent over HTTP/1.1 if the `HostOs` header's value starts or ends with whitespace.

HTTP/2 is not affected by this bug as the underlying `h2` package trims the whitespace itself.

This fixes #1087.

### Notes

Leading and trailing whitespace in any request header value will prevent requests from being sent when using HTTP 1.1 as `h11` package's normalize_and_validate function (https://github.com/python-hyper/h11/blob/62c5068c971579d61fa1b55373390e12f25fd856/h11/_headers.py#L152) validates the header using a regex that explicitly disallows trailing whitespace. `h2`, used for HTTP 2 traffic, trims the values itself.

The HostOs header can end up with leading whitespace if `platform.system()` returns an empty string (which per Python's documentation is possible: "An empty string is returned if the value cannot be determined.")

 The HostOs header can end up with trailing whitespace in two cases:
* If `platform.version()` returns an empty string (which per Python's documentation is possible: "An empty string is returned if the value cannot be determined.")
* If `platform.version()` returns a string that ends with a whitespace character.

The latter case can happen on e.g. a Linux platform where `platform.version()` usually returns the kernel version. The `uname` struct fields are 65 characters (as seen here: https://github.com/torvalds/linux/blob/9154c4af7829b6f82712b4d1a2a720adddacdb8d/include/uapi/linux/utsname.h#L25) - A kernel version longer than 65 characters may end up being with a whitespace as the last character.

## Testing Instructions

* Use a kernel version that ends in a whitespace (e.g. some of the triple-digit Ubuntu backported HWE kernels will end up cutting off the timestamp at a whitespace)
* Connect to Microsoft Graph while Microsoft Graph cannot establish an HTTP/2 connection for some reason
* See that a request is made - Without this fix, `h11` would give an `Invalid header value` error