### PR TITLE
Defer requests import in PageIterator to reduce cold import time

### DIFF
--- a/src/msgraph_core/tasks/page_iterator.py
+++ b/src/msgraph_core/tasks/page_iterator.py
@@ -11,7 +11,7 @@ The PageIterator class uses the Parsable interface to parse the responses
  server, and the PageResult class to represent the pages.
 
 This module also imports the necessary types and exceptions from the
-typing, requests.exceptions, kiota_http.httpx_request_adapter,
+typing, kiota_http.httpx_request_adapter,
  kiota_abstractions.method, kiota_abstractions.headers_collection,
 kiota_abstractions.request_information, kiota_abstractions.serialization.parsable,
 and models modules.
@@ -25,7 +25,6 @@ from kiota_abstractions.method import Method
 from kiota_abstractions.request_adapter import RequestAdapter
 from kiota_abstractions.request_information import RequestInformation
 from kiota_abstractions.serialization import Parsable, ParsableFactory
-from requests.exceptions import InvalidURL
 
 from msgraph_core.models.page_result import (
     PageResult,  # pylint: disable=no-name-in-module, import-error
@@ -201,6 +200,9 @@ Methods:
         if not next_link:
             raise ValueError('The response does not contain a nextLink.')
         if not next_link.startswith('http'):
+            # Imported lazily: importing requests at module level adds ~350 ms
+            # to every `from msgraph import GraphServiceClient` cold start.
+            from requests.exceptions import InvalidURL
             raise InvalidURL('Could not parse nextLink URL.')
         request_info = RequestInformation()
         request_info.http_method = Method.GET

--- a/src/msgraph_core/tasks/page_iterator.py
+++ b/src/msgraph_core/tasks/page_iterator.py
@@ -202,7 +202,7 @@ Methods:
         if not next_link.startswith('http'):
             # Imported lazily: importing requests at module level adds ~350 ms
             # to every `from msgraph import GraphServiceClient` cold start.
-            from requests.exceptions import InvalidURL
+            from requests.exceptions import InvalidURL  # pylint: disable=import-outside-toplevel
             raise InvalidURL('Could not parse nextLink URL.')
         request_info = RequestInformation()
         request_info.http_method = Method.GET


### PR DESCRIPTION
## Problem

`msgraph_core/tasks/page_iterator.py` imports `InvalidURL` from `requests.exceptions` at module level. This is the **only** use of `requests` in msgraph-core, and it drags the whole `requests` package (+ its `charset_normalizer` dependency) into every `from msgraph import GraphServiceClient` — ~350 ms cumulative, roughly 20–25 % of cold import time (profiled with `python -X importtime`, msgraph-sdk 1.58.0, Python 3.11, Linux). The SDK transport is httpx, so requests is loaded purely for one exception class.

Additionally, `requests` is not a declared dependency of this package (not in `pyproject.toml`) — it currently works only because it arrives transitively.

Context: profiling details in microsoftgraph/msgraph-sdk-python#904.

## Change

Import `InvalidURL` lazily at the single raise site in `fetch_next_page`. Exception type and behavior are unchanged, so existing code catching `requests.exceptions.InvalidURL` keeps working.

## Verification

- `python -c "from msgraph_core.tasks.page_iterator import PageIterator"` no longer loads `requests` (verified via `sys.modules`)
- Full test suite: 74 passed