### PR TITLE
chore: update kiota dependencies to 1.11.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,9 @@ version = "1.4.0"
 authors = [{name = "Microsoft", email = "graphtooling+python@microsoft.com"}]
 description = "Core component of the Microsoft Graph Python SDK"
 dependencies = [
-    "microsoft-kiota-abstractions >=1.10.1,<2.0.0",
-    "microsoft-kiota-authentication-azure >=1.10.1,<2.0.0",
-    "microsoft-kiota-http >=1.10.1,<2.0.0",
+    "microsoft-kiota-abstractions >=1.11.6,<2.0.0",
+    "microsoft-kiota-authentication-azure >=1.11.6,<2.0.0",
+    "microsoft-kiota-http >=1.11.6,<2.0.0",
     "httpx[http2] >=0.23.0",
 ]
 requires-python = ">=3.10"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -144,13 +144,13 @@ httpx[http2]==0.28.1
 
 hyperframe==6.1.0 ; python_full_version >= '3.6.1'
 
-microsoft-kiota-abstractions==1.10.1
+microsoft-kiota-abstractions==1.11.6
 
-microsoft-kiota-authentication-azure==1.10.1
+microsoft-kiota-authentication-azure==1.11.6
 
-microsoft-kiota-http==1.10.1
+microsoft-kiota-http==1.11.6
 
-microsoft-kiota-serialization-json==1.10.1
+microsoft-kiota-serialization-json==1.11.6
 
 multidict==6.6.4 ; python_version >= '3.7'
 


### PR DESCRIPTION
Updates all microsoft-kiota dependency versions from 1.10.1 to 1.11.6 in both pyproject.toml and requirements-dev.txt.