### PR TITLE
chore(deps): consolidate dependabot dependency updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/release-please-gha.yml
+++ b/.github/workflows/release-please-gha.yml
@@ -19,7 +19,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Generate GitHub App token
         id: app-token

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -107,7 +107,7 @@ tomli==2.2.1 ; python_version < '3.11'
 
 tomlkit==0.13.3 ; python_version >= '3.7'
 
-trio==0.31.0
+trio==0.33.0
 
 types-python-dateutil==2.9.0.20260518
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -27,7 +27,7 @@ coverage[toml]==7.10.6 ; python_version >= '3.7'
 
 cryptography==46.0.7 ; python_version >= '3.7'
 
-dill==0.4.0
+dill==0.4.1
 
 exceptiongroup==1.3.0 ; python_version < '3.11'
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -29,7 +29,7 @@ cryptography==46.0.7 ; python_version >= '3.7'
 
 dill==0.4.0
 
-exceptiongroup==1.3.0 ; python_version < '3.11'
+exceptiongroup==1.3.1 ; python_version < '3.11'
 
 idna==3.15 ; python_version >= '3.5'
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -152,7 +152,7 @@ microsoft-kiota-http==1.10.1
 
 microsoft-kiota-serialization-json==1.10.1
 
-multidict==6.6.4 ; python_version >= '3.7'
+multidict==6.7.1 ; python_version >= '3.7'
 
 uritemplate==4.2.0 ; python_version >= '3.6'
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -111,7 +111,7 @@ trio==0.31.0
 
 types-python-dateutil==2.9.0.20260518
 
-types-requests==2.32.4.20250809; python_version >= '3.7'
+types-requests==2.33.0.20260518; python_version >= '3.7'
 urllib3==2.7.0 ; python_version >= '3.7'
 typing-extensions==4.15.0 ; python_version >= '3.7'
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -23,7 +23,7 @@ click==8.1.8 ; python_version >= '3.6'
 
 colorama==0.4.6 ; os_name == 'nt'
 
-coverage[toml]==7.10.6 ; python_version >= '3.7'
+coverage[toml]==7.14.1 ; python_version >= '3.7'
 
 cryptography==46.0.7 ; python_version >= '3.7'
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -25,7 +25,7 @@ colorama==0.4.6 ; os_name == 'nt'
 
 coverage[toml]==7.10.6 ; python_version >= '3.7'
 
-cryptography==46.0.7 ; python_version >= '3.7'
+cryptography==48.0.1 ; python_version >= '3.7'
 
 dill==0.4.0
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ async-generator==1.10 ; python_version >= '3.5'
 
 asyncmock==0.4.2
 
-attrs==25.3.0 ; python_version >= '3.7'
+attrs==26.1.0 ; python_version >= '3.7'
 
 azure-core==1.41.0 ; python_version >= '3.7'
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -126,7 +126,7 @@ aiohttp==3.13.5 ; python_version >= '3.6'
 
 aiosignal==1.4.0 ; python_version >= '3.7'
 
-anyio==4.10.0 ; python_version >= '3.7'
+anyio==4.13.0 ; python_version >= '3.7'
 
 async-timeout==5.0.1 ; python_version >= '3.6'
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,7 +17,7 @@ certifi==2025.8.3 ; python_version >= '3.6'
 
 cffi==1.17.1 ; os_name == 'nt' and implementation_name != 'pypy'
 
-charset-normalizer==3.4.3 ; python_full_version >= '3.7.0'
+charset-normalizer==3.4.7 ; python_full_version >= '3.7.0'
 
 click==8.1.8 ; python_version >= '3.6'
 


### PR DESCRIPTION
Consolidates the following dependabot PRs into a single update:

- #1093 — actions/checkout 6 → 7
- #1091 — cryptography 46.0.7 → 48.0.1
- #1080 — attrs 25.3.0 → 26.1.0
- #1079 — multidict 6.6.4 → 6.7.1
- #1075 — types-requests 2.32.4.20250809 → 2.33.0.20260518
- #1074 — anyio 4.10.0 → 4.13.0
- #1073 — trio 0.31.0 → 0.33.0
- #1072 — exceptiongroup 1.3.0 → 1.3.1
- #1071 — dill 0.4.0 → 0.4.1
- #1070 — coverage 7.10.6 → 7.14.1
- #1069 — charset-normalizer 3.4.3 → 3.4.7

**Skipped:** #1081 (wrapt)