### PR TITLE
fix: PageIterator does not correctly capture the @odata.deltaLink

### DIFF
--- a/src/msgraph_core/models/page_result.py
+++ b/src/msgraph_core/models/page_result.py
@@ -25,6 +25,7 @@ T = TypeVar('T')
 @dataclass
 class PageResult(Parsable):
     odata_next_link: Optional[str] = None
+    odata_delta_link: Optional[str] = None
     value: Optional[list[Parsable]] = None
 
     @staticmethod
@@ -49,6 +50,8 @@ class PageResult(Parsable):
         return {
             "@odata.nextLink":
             lambda x: setattr(self, "odata_next_link", x.get_str_value()),
+            "@odata.deltaLink":
+            lambda x: setattr(self, "odata_delta_link", x.get_str_value()),
             "value":
             lambda x: setattr(
                 self,
@@ -69,4 +72,5 @@ class PageResult(Parsable):
         if not writer:
             raise TypeError("Writer cannot be null")
         writer.write_str_value("@odata.nextLink", self.odata_next_link)
+        writer.write_str_value("@odata.deltaLink", self.odata_delta_link)
         writer.write_collection_of_object_values("value", self.value)

--- a/src/msgraph_core/models/page_result.py
+++ b/src/msgraph_core/models/page_result.py
@@ -25,8 +25,8 @@ T = TypeVar('T')
 @dataclass
 class PageResult(Parsable):
     odata_next_link: Optional[str] = None
-    odata_delta_link: Optional[str] = None
     value: Optional[list[Parsable]] = None
+    odata_delta_link: Optional[str] = None
 
     @staticmethod
     def create_from_discriminator_value(parse_node: Optional[ParseNode] = None) -> PageResult:

--- a/src/msgraph_core/tasks/page_iterator.py
+++ b/src/msgraph_core/tasks/page_iterator.py
@@ -83,9 +83,7 @@ Methods:
         self._next_link = response.get('odata_next_link', '') if isinstance(
             response, dict
         ) else getattr(response, 'odata_next_link', '')
-        self._delta_link = response.get('@odata.deltaLink', '') if isinstance(
-            response, dict
-        ) else getattr(response, 'odata_delta_link', '')
+        self._delta_link = self._extract_delta_link(response)
 
         if page is not None:
             self.current_page = page
@@ -151,13 +149,31 @@ Methods:
         next_link = response.odata_next_link if response and hasattr(
             response, 'odata_next_link'
         ) else None
-        delta_link = response.odata_delta_link if response and hasattr(
-            response, 'odata_delta_link'
-        ) else None
+        delta_link = self._extract_delta_link(response) if response else None
         if delta_link:
             self._delta_link = delta_link
         value = response.value if response and hasattr(response, 'value') else None
         return PageResult(odata_next_link=next_link, value=value)
+
+    @staticmethod
+    def _extract_delta_link(response: Union[T, dict, object]) -> str:
+        """
+        Extracts the '@odata.deltaLink' from a response.
+        Checks the additional data bag first (for models that do not
+        explicitly declare the field), then falls back to the typed
+        'odata_delta_link' attribute.
+        Args:
+            response (Union[T, dict, object]): The response to extract the
+            delta link from.
+        Returns:
+            str: The delta link, or an empty string if none is present.
+        """
+        if isinstance(response, dict):
+            return response.get('@odata.deltaLink', '')
+        additional_data = getattr(response, 'additional_data', None)
+        if additional_data and additional_data.get('@odata.deltaLink'):
+            return additional_data.get('@odata.deltaLink')
+        return getattr(response, 'odata_delta_link', '')
 
     @staticmethod
     def convert_to_page(response: Union[T, list, object]) -> PageResult:

--- a/src/msgraph_core/tasks/page_iterator.py
+++ b/src/msgraph_core/tasks/page_iterator.py
@@ -32,6 +32,8 @@ from msgraph_core.models.page_result import (
 
 T = TypeVar('T', bound=Parsable)
 
+ODATA_DELTA_LINK_KEY = '@odata.deltaLink'
+
 
 class PageIterator:
     """
@@ -156,7 +158,7 @@ Methods:
         return PageResult(odata_next_link=next_link, value=value)
 
     @staticmethod
-    def _extract_delta_link(response: Union[T, dict, object]) -> str:
+    def _extract_delta_link(response: T | dict | object) -> str:
         """
         Extracts the '@odata.deltaLink' from a response.
         Checks the additional data bag first (for models that do not
@@ -169,10 +171,10 @@ Methods:
             str: The delta link, or an empty string if none is present.
         """
         if isinstance(response, dict):
-            return response.get('@odata.deltaLink', '')
+            return response.get(ODATA_DELTA_LINK_KEY, '')
         additional_data = getattr(response, 'additional_data', None)
-        if additional_data and additional_data.get('@odata.deltaLink'):
-            return additional_data.get('@odata.deltaLink')
+        if additional_data and additional_data.get(ODATA_DELTA_LINK_KEY):
+            return additional_data.get(ODATA_DELTA_LINK_KEY)
         return getattr(response, 'odata_delta_link', '')
 
     @staticmethod

--- a/src/msgraph_core/tasks/page_iterator.py
+++ b/src/msgraph_core/tasks/page_iterator.py
@@ -85,7 +85,7 @@ Methods:
         ) else getattr(response, 'odata_next_link', '')
         self._delta_link = response.get('@odata.deltaLink', '') if isinstance(
             response, dict
-        ) else getattr(response, '@odata.deltaLink', '')
+        ) else getattr(response, 'odata_delta_link', '')
 
         if page is not None:
             self.current_page = page
@@ -151,8 +151,13 @@ Methods:
         next_link = response.odata_next_link if response and hasattr(
             response, 'odata_next_link'
         ) else None
+        delta_link = response.odata_delta_link if response and hasattr(
+            response, 'odata_delta_link'
+        ) else None
+        if delta_link:
+            self._delta_link = delta_link
         value = response.value if response and hasattr(response, 'value') else None
-        return PageResult(next_link, value)
+        return PageResult(odata_next_link=next_link, value=value)
 
     @staticmethod
     def convert_to_page(response: Union[T, list, object]) -> PageResult:
@@ -184,7 +189,7 @@ Methods:
             parsable_page, dict
         ) else getattr(parsable_page, 'odata_next_link', '')
 
-        return PageResult(next_link, value)
+        return PageResult(odata_next_link=next_link, value=value)
 
     async def fetch_next_page(self) -> Optional[Union[T, PageResult]]:
         """

--- a/tests/tasks/test_page_iterator.py
+++ b/tests/tasks/test_page_iterator.py
@@ -101,6 +101,31 @@ def test_convert_to_page(first_page_data):  # pylint: disable=redefined-outer-na
 
 
 @pytest.mark.asyncio
+async def test_delta_link_updated_from_final_page():
+    """Reproduces the bug where the delta link from the last page of a
+    multi-page delta sync was never captured on the PageIterator."""
+    first_page = PageResult(odata_next_link='https://graph.microsoft.com/v1.0/next', value=[1, 2])
+    final_page = PageResult(
+        odata_next_link=None,
+        odata_delta_link='https://graph.microsoft.com/v1.0/delta?token=final',
+        value=[3, 4],
+    )
+
+    adapter = Mock()
+    adapter.send_async = AsyncMock(return_value=final_page)
+
+    page_iterator = PageIterator(first_page, adapter)
+    # No delta link on the first page, matching the real multi-page scenario.
+    assert not page_iterator.delta_link
+
+    items = []
+    await page_iterator.iterate(lambda item: items.append(item) or True)
+
+    assert items == [1, 2, 3, 4]
+    assert page_iterator.delta_link == 'https://graph.microsoft.com/v1.0/delta?token=final'
+
+
+@pytest.mark.asyncio
 async def test_iterate():
     # Mock the next method to return None after the first call
     with patch.object(PageIterator, 'next', new_callable=AsyncMock) as mock_next:

--- a/tests/tasks/test_page_iterator.py
+++ b/tests/tasks/test_page_iterator.py
@@ -125,6 +125,39 @@ async def test_delta_link_updated_from_final_page():
     assert page_iterator.delta_link == 'https://graph.microsoft.com/v1.0/delta?token=final'
 
 
+class _CustomPage:  # pylint: disable=too-few-public-methods
+    """A page response whose model does not declare 'odata_delta_link' and
+    instead carries it in the additional data bag, like a Kiota-generated
+    collection response that doesn't model the deltaLink property."""
+
+    def __init__(self, value, odata_next_link=None, additional_data=None):
+        self.value = value
+        self.odata_next_link = odata_next_link
+        self.additional_data = additional_data or {}
+
+
+@pytest.mark.asyncio
+async def test_delta_link_falls_back_to_additional_data():
+    """Reproduces the gap where a model without a typed 'odata_delta_link'
+    attribute stores the delta link in additional_data instead."""
+    first_page = PageResult(odata_next_link='https://graph.microsoft.com/v1.0/next', value=[1, 2])
+    final_page = _CustomPage(
+        value=[3, 4],
+        additional_data={'@odata.deltaLink': 'https://graph.microsoft.com/v1.0/delta?token=final'},
+    )
+
+    adapter = Mock()
+    adapter.send_async = AsyncMock(return_value=final_page)
+
+    page_iterator = PageIterator(first_page, adapter)
+
+    items = []
+    await page_iterator.iterate(lambda item: items.append(item) or True)
+
+    assert items == [1, 2, 3, 4]
+    assert page_iterator.delta_link == 'https://graph.microsoft.com/v1.0/delta?token=final'
+
+
 @pytest.mark.asyncio
 async def test_iterate():
     # Mock the next method to return None after the first call

--- a/tests/tasks/test_page_iterator.py
+++ b/tests/tasks/test_page_iterator.py
@@ -1,4 +1,5 @@
 import os
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch, Mock
 
 import pytest
@@ -125,24 +126,16 @@ async def test_delta_link_updated_from_final_page():
     assert page_iterator.delta_link == 'https://graph.microsoft.com/v1.0/delta?token=final'
 
 
-class _CustomPage:  # pylint: disable=too-few-public-methods
-    """A page response whose model does not declare 'odata_delta_link' and
-    instead carries it in the additional data bag, like a Kiota-generated
-    collection response that doesn't model the deltaLink property."""
-
-    def __init__(self, value, odata_next_link=None, additional_data=None):
-        self.value = value
-        self.odata_next_link = odata_next_link
-        self.additional_data = additional_data or {}
-
-
 @pytest.mark.asyncio
 async def test_delta_link_falls_back_to_additional_data():
     """Reproduces the gap where a model without a typed 'odata_delta_link'
-    attribute stores the delta link in additional_data instead."""
+    attribute stores the delta link in additional_data instead, like a
+    Kiota-generated collection response that doesn't model the deltaLink
+    property."""
     first_page = PageResult(odata_next_link='https://graph.microsoft.com/v1.0/next', value=[1, 2])
-    final_page = _CustomPage(
+    final_page = SimpleNamespace(
         value=[3, 4],
+        odata_next_link=None,
         additional_data={'@odata.deltaLink': 'https://graph.microsoft.com/v1.0/delta?token=final'},
     )
 


### PR DESCRIPTION
## Summary
`PageIterator.delta_link` was effectively always empty for real usage, for two separate reasons:

- `PageResult` had no field or deserializer for `@odata.deltaLink`, so it was silently dropped when a page response was parsed.
- `PageIterator.__init__` read the delta link via `getattr(response, '@odata.deltaLink', '')`, which is never a valid attribute name on a Kiota `Parsable` model, so it always fell through to `''`.
- Even once fixed, the delta link was only ever inspected on the initial response passed to the constructor and never updated as later pages were fetched via `next()` — but in a real multi-page delta sync, the delta link normally only appears on the final page.

This PR:
- Adds an `odata_delta_link` field (and its `@odata.deltaLink` (de)serialization) to `PageResult`.
- Fixes `PageIterator` to read the delta link correctly and to keep it updated as `next()` advances through pages.
- Adds an `additional_data` fallback when extracting the delta link, matching how the .NET SDK's `PageIterator` checks `AdditionalData` before its strongly-typed `OdataDeltaLink` property — this covers a custom `constructor_callable` model that doesn't declare the field explicitly.

## Test plan
- [x] `pytest tests/tasks/test_page_iterator.py tests/tasks/test_page_result.py` — added two regression tests: a multi-page delta sync where the delta link only appears on the final page, and a page model that only carries the delta link in `additional_data`.
- [x] Full suite: `pytest tests` — 76 passed.
- [x] `pylint src/msgraph_core/tasks/page_iterator.py src/msgraph_core/models/page_result.py` — 10.00/10.