### PR TITLE
fix: build BatchRequestItem urls relative to the API version

### DIFF
--- a/src/msgraph_core/requests/batch_request_item.py
+++ b/src/msgraph_core/requests/batch_request_item.py
@@ -21,8 +21,8 @@ class StreamInterface(BytesIO):
 
 
 class BatchRequestItem(Parsable):
-    API_VERSION_REGEX = re.compile(r'/\/(v1.0|beta)/')
-    ME_TOKEN_REGEX = re.compile(r'/\/users\/me-token-to-replace/')
+    API_VERSION_REGEX = re.compile(r'/(v1\.0|beta)(?=/|$)')
+    ME_TOKEN_REGEX = re.compile(r'/users/me-token-to-replace')
 
     def __init__(
         self,
@@ -47,7 +47,7 @@ class BatchRequestItem(Parsable):
             self._method = request_information.http_method
         self._headers: Optional[dict[str, str]] = request_information.request_headers
         self._body = request_information.content
-        self.url = request_information.url.replace('/users/me-token-to-replace', '/me', 1)
+        self.set_url(request_information.url)
         self._depends_on: Optional[list[str]] = []
         if depends_on is not None:
             self.set_depends_on(depends_on)

--- a/tests/requests/test_batch_request_item.py
+++ b/tests/requests/test_batch_request_item.py
@@ -32,7 +32,7 @@ def batch_request_item(request_info):
 def test_initialization(batch_request_item, request_info):
     assert batch_request_item.id == "123"
     assert batch_request_item.method == "GET"
-    assert batch_request_item.url == base_url
+    assert batch_request_item.url == "/me"
     assert batch_request_item.headers == {"content-type": "application/json"}
     assert batch_request_item.body == b'{"key": "value"}'
 
@@ -43,7 +43,7 @@ def test_create_with_urllib_request():
     urllib_request.data = b'{"key": "value"}'
     batch_request_item = BatchRequestItem.create_with_urllib_request(urllib_request)
     assert batch_request_item.method == "POST"
-    assert batch_request_item.url == "https://graph.microsoft.com/v1.0/me"
+    assert batch_request_item.url == "/me"
     assert batch_request_item.body == b'{"key": "value"}'
 
 
@@ -54,7 +54,22 @@ def test_set_depends_on(batch_request_item):
 
 def test_set_url(batch_request_item):
     batch_request_item.set_url("https://graph.microsoft.com/v1.0/me")
-    assert batch_request_item.url == "/v1.0/me"
+    assert batch_request_item.url == "/me"
+
+
+def test_set_url_beta(batch_request_item):
+    batch_request_item.set_url("https://graph.microsoft.com/beta/me/messages?$top=5#frag")
+    assert batch_request_item.url == "/me/messages?$top=5#frag"
+
+
+def test_set_url_already_relative(batch_request_item):
+    batch_request_item.set_url("/users/u1/messages")
+    assert batch_request_item.url == "/users/u1/messages"
+
+
+def test_set_url_keeps_version_like_segments(batch_request_item):
+    batch_request_item.set_url("https://graph.microsoft.com/v1.0/sites/beta-site/lists")
+    assert batch_request_item.url == "/sites/beta-site/lists"
 
 
 def test_constructor_url_replacement():
@@ -66,7 +81,7 @@ def test_constructor_url_replacement():
 
     batch_request_item = BatchRequestItem(request_info)
 
-    assert batch_request_item.url == "https://graph.microsoft.com/v1.0/me"
+    assert batch_request_item.url == "/me"
 
 
 def test_set_url_replacement():
@@ -79,7 +94,7 @@ def test_set_url_replacement():
     batch_request_item = BatchRequestItem(request_info)
     batch_request_item.set_url("https://graph.microsoft.com/v1.0/users/me-token-to-replace")
 
-    assert batch_request_item.url == "/v1.0/me"
+    assert batch_request_item.url == "/me"
 
 
 def test_constructor_url_replacement_with_query():
@@ -91,7 +106,7 @@ def test_constructor_url_replacement_with_query():
 
     batch_request_item = BatchRequestItem(request_info)
 
-    assert batch_request_item.url == "https://graph.microsoft.com/v1.0/me?param=value"
+    assert batch_request_item.url == "/me?param=value"
 
 
 def test_id_property(batch_request_item):
@@ -138,7 +153,7 @@ def test_serialize_json(batch_request_item):
     content = json.loads(writer.get_serialized_content())
     assert content["id"] == "123"
     assert content["method"] == "GET"
-    assert content["url"] == base_url
+    assert content["url"] == "/me"
     assert content["headers"] == {"content-type": "application/json"}
     assert content["body"] == {"key": "value"}
 


### PR DESCRIPTION
## Overview

Fixes #1116. `BatchRequestItem` built from a `RequestInformation` kept the full `https://graph.microsoft.com/v1.0/...` URL, so the serialized `$batch` body carried absolute URLs. `set_url()` is meant to strip the version, but `API_VERSION_REGEX = re.compile(r'/\/(v1.0|beta)/')` reads as a JavaScript regex literal ported as-is: in Python both `/` and `\/` are literal slashes, so it only ever matched `//v1.0/`.

Three lines: the regex is now `r'/(v1\.0|beta)(?=/|$)'` (matches the version as a whole path segment, so `/sites/beta-site` is left alone), `ME_TOKEN_REGEX` gets the same treatment, and the constructor goes through `set_url()`, which already handles the me-token, query string and fragment. The result matches what the JavaScript SDK does in `BatchRequestContent.ts` (it strips scheme, host and version, and its tests expect `/me/drive/root/children`).

### Notes

The existing tests pinned the old behaviour (`url == base_url` after construction, `"/v1.0/me"` after `set_url`), so those assertions changed to the relative form. Anyone who read `item.url` back and stripped the version themselves, as we did, gets an already relative URL now; the batch body they send does not change. Open PRs #711 and #996 touch `serialize()` in the same file, not these lines.

## Testing Instructions

* `pip install -r requirements-dev.txt`, then `pytest tests/requests/test_batch_request_item.py`: 3 new cases (beta URL with query and fragment, an already relative path, a version-like segment inside the path), 7 updated ones.
* Full suite: 77 passed. `yapf -dr src`, `mypy src` and `pylint src --disable=W --rcfile=.pylintrc` clean.
* Before/after on a `POST .../v1.0/users/u1/messages/m1/move` item: the serialized body's `url` goes from the absolute URL to `/users/u1/messages/m1/move`.
